### PR TITLE
Add support for declaring unmeasured data

### DIFF
--- a/common/inc/sgx_defs.h
+++ b/common/inc/sgx_defs.h
@@ -51,4 +51,7 @@
 
 #define SGX_NOCONVENTION /* Empty.  No calling convention specified. */
 
+#define __unmeasured __attribute__((__section__(".sgx.unmeasured, \"wa\", @nobits#")))
+#define __unmeasured_aligned __unmeasured __attribute__((aligned(0x1000)))
+
 #endif /* !_SGX_DEFS_H_ */

--- a/psw/urts/parser/binparser.h
+++ b/psw/urts/parser/binparser.h
@@ -74,6 +74,10 @@ public:
 
     virtual uint64_t get_metadata_block_size() const = 0;
 
+    virtual uint64_t get_unmeasured_address() const = 0;
+
+    virtual uint64_t get_unmeasured_size() const = 0;
+
     virtual const uint8_t* get_start_addr() const = 0;
 
     // Get a vector of sections to be loaded

--- a/psw/urts/parser/elfparser.h
+++ b/psw/urts/parser/elfparser.h
@@ -59,6 +59,10 @@ public:
 
     uint64_t get_metadata_block_size() const;
 
+    uint64_t get_unmeasured_address() const;
+
+    uint64_t get_unmeasured_size() const;
+
     const uint8_t* get_start_addr() const;
 
     // The `section' here is a section in PE's concept.
@@ -96,6 +100,8 @@ private:
     const Section*      m_tls_section;
     uint64_t            m_metadata_offset;
     uint64_t            m_metadata_block_size;/*multiple metadata block size*/
+    uint64_t            m_unmeasured_address;
+    uint64_t            m_unmeasured_size;
 
     ElfW(Dyn)           m_dyn_info[DT_NUM + DT_ADDRNUM];
 


### PR DESCRIPTION
Add recognition of a special ELF section, '.sgx.unmeasured', that can
be used by enclaves to declare data that should not contribute to the
measurement of an enclave.  The section's address and size must both
be page aligned.  Pages that are wholly contained by the unmeasured
sections are built with ADD_PAGE_ONLY, i.e. they skip EEXTEND.

Report an error if the unmeasured section is not properly aligned, or
if the section contains any initialized data.  Assert if the section
straddles multiple segments (invalid ELF file).

Define the macros '__unmeasured' and '__unmeasured_aligned' for use
by enclave developers in declaring unmeasured data.  The aligned macro
is intended to be used once per enclave to ensure proper alignment.

Signed-off-by: Sean Christopherson sean.j.christopherson@intel.com

<br>
**Summary**
This is essentially a RFC on the concept of providing enclave developers with the option of declaring data as unmeasured.  

On my system, EEXTEND adds a latency of 25-42 microseconds per 4k page, e.g. an application with 12MiB of unmeasured data saves ~80 milliseconds during enclave creation when compiled with this patch.  If the majority of the code/data being loaded for the application is unmeasured data, then this can result in a 2x-5x reduction in time spent creating the enclave.

The intended usage model of __unmeasured is for cases where the data is guaranteed to be accessed in a read-after-write model, e.g. buffers, static memory pools, etc...  Without defined workloads it's difficult to determine how many users would benefit from this feature, but I think there is value in being able to "allocate" large chunks of memory without having to suffer the overhead of EEXTEND or coordinate (and fine tune) the heap size with the code base.

<br>
**Sample Usage:**

``` c
static STREAM_TYPE __unmeasured_aligned a[STREAM_ARRAY_SIZE+OFFSET], __unmeasured b[STREAM_ARRAY_SIZE+OFFSET], __unmeasured c[STREAM_ARRAY_SIZE+OFFSET];
```

<br>
**Results:**
The table below shows the latency, in seconds, of sgx_create_enclave for an enclave that defines a large buffer using each of the methods.  Allocations other than the buffer are minimal, e.g. 16kb of stack and ~80kb of code/data.  For any sizable buffer, skipping EEXTEND for the buffer via the heap or .sgx.unmeasured yields significantly lower latency during enclave creation.

I'm in the process of investigating why using the heap is slower than .sgx.unmeasured, I expected them to be roughly equivalent since this benchmark does not incorporate any actual malloc calls.

| Method | 72mb | 12mb | 384kb |
| --- | --- | --- | --- |
| .bss | 0.594111 | 0.101852 | 0.004779 |
| heap | 0.147291 | 0.026281 | 0.002564 |
| .sgx... | 0.104936 | 0.019890 | 0.002129 |
