### PR TITLE
edger8r, psw: Add [enclave_id] non-pointer attribute

### DIFF
--- a/psw/urts/linux/sig_handler.cpp
+++ b/psw/urts/linux/sig_handler.cpp
@@ -130,7 +130,7 @@ void sig_handler(int signum, siginfo_t* siginfo, void *priv)
         }
         //If we can't fix the exception within enclave, then give the handle to other signal hanlder.
         //Call the previous signal handler. The default signal handler should terminate the application.
-        
+
         enclave->rdunlock();
         CEnclavePool::instance()->unref_enclave(enclave);
     }
@@ -248,11 +248,11 @@ int do_ecall(const int fn, const void *ocall_table, const void *ms, CTrustThread
     return status;
 }
 
-int do_ocall(const bridge_fn_t bridge, void *ms)
+int do_ocall(const bridge_fn_t bridge, sgx_enclave_id_t enclave_id, void *ms)
 {
     int error = SGX_ERROR_UNEXPECTED;
 
-    error = bridge(ms);
+    error = bridge(enclave_id, ms);
 
     save_and_clean_xfeature_regs(NULL);
 

--- a/psw/urts/tcs.h
+++ b/psw/urts/tcs.h
@@ -36,6 +36,7 @@
 #include "se_wrapper.h"
 #include "util.h"
 #include "sgx_error.h"
+#include "sgx_eid.h"
 #include "se_debugger_lib.h"
 #include "se_lock.hpp"
 #include <vector>
@@ -43,7 +44,7 @@
 
 using namespace std;
 
-typedef int (*bridge_fn_t)(const void*);
+typedef int (*bridge_fn_t)(sgx_enclave_id_t enclave_id, const void*);
 
 class CEnclave;
 
@@ -87,7 +88,7 @@ protected:
     inline CTrustThread * get_free_thread();
     int bind_thread(const se_thread_id_t thread_id, CTrustThread * const trust_thread);
     CTrustThread * get_bound_thread(const se_thread_id_t thread_id);
-    
+
     vector<CTrustThread *>                  m_free_thread_vector;
     Node<se_thread_id_t, CTrustThread *>    *m_thread_list;
     Mutex                                   m_thread_mutex; //protect both thread_cache list and fress tcs list. The mutex is recursive.

--- a/sdk/edger8r/linux/Ast.ml
+++ b/sdk/edger8r/linux/Ast.ml
@@ -86,10 +86,15 @@ type ptr_attr = {
   pa_chkptr     : bool;       (* Whether to generate code to check pointer *)
 }
 
+type non_ptr_attr = {
+  npa_enclave_id : bool;
+}
+let default_non_ptr_attr = { npa_enclave_id = false; }
+
 (* parameter type *)
 type parameter_type =
-  | PTVal of atype            (* Passed by value *)
-  | PTPtr of atype * ptr_attr (* Passed by address *)
+  | PTVal of atype * non_ptr_attr (* Passed by value *)
+  | PTPtr of atype * ptr_attr     (* Passed by address *)
 
 type call_conv = CC_CDECL | CC_STDCALL | CC_FASTCALL | CC_NONE
 
@@ -241,7 +246,7 @@ let rec get_tystr (ty: atype) =
 (* Get the plain `atype' from a `parameter_type'. *)
 let get_param_atype (pt: parameter_type) =
   match pt with
-    | PTVal t      -> t
+    | PTVal (t, _) -> t
     | PTPtr (t, _) -> t
 
 (* Convert attr_value to string *)

--- a/sdk/edger8r/linux/Parser.mly
+++ b/sdk/edger8r/linux/Parser.mly
@@ -175,6 +175,22 @@ let get_ptr_attr (attr_list: (string * Ast.attr_value) list) =
     then check_invalid_ary_attr pattr
     else check_invalid_ptr_size pattr |> check_ptr_dir
 
+let get_non_ptr_attr (attr_list: (string * Ast.attr_value) list) =
+  let update_attr (key: string) (value: Ast.attr_value) (ores: Ast.non_ptr_attr option) =
+    match ores with
+        None -> None
+      | Some res -> match key with
+            "enclave_id" -> Some { res with Ast.npa_enclave_id = true; }
+          | _ -> Some res
+  in
+  let rec do_get_non_ptr_attr alist res_attr =
+    match alist with
+        [] -> res_attr
+      | (k,v) :: xs -> do_get_non_ptr_attr xs (update_attr k v res_attr)
+  in do_get_non_ptr_attr attr_list (Some Ast.default_non_ptr_attr)
+
+
+
 (* Untrusted functions can have these attributes:
  *
  * a. 3 mutual exclusive calling convention specifier:
@@ -366,23 +382,26 @@ param_type: attr_block all_type {
       Ast.Ptr _ -> fun x -> Ast.PTPtr($2, get_ptr_attr $1)
     | _         ->
       if $1 <> [] then
-        let attr = get_ptr_attr $1 in
         match $2 with
           Ast.Foreign s ->
-            if attr.Ast.pa_isptr || attr.Ast.pa_isary then fun x -> Ast.PTPtr($2, attr)
-            else
-              (* thinking about 'user_defined_type var[4]' *)
-              fun is_ary ->
-                if is_ary then Ast.PTPtr($2, attr)
-                else failwithf "`%s' is considerred plain type but decorated with pointer attributes" s
-        | _ ->
-          fun is_ary ->
+          let attr = get_ptr_attr $1 in
+          if attr.Ast.pa_isptr || attr.Ast.pa_isary then fun x -> Ast.PTPtr($2, attr)
+          else
+            (* thinking about 'user_defined_type var[4]' *)
+            fun is_ary ->
             if is_ary then Ast.PTPtr($2, attr)
-            else failwithf "unexpected pointer attributes for `%s'" (Ast.get_tystr $2)
+            else failwithf "`%s' is considerred plain type but decorated with pointer attributes" s
+        | _ ->
+           fun is_ary ->
+           if is_ary then Ast.PTPtr($2, get_ptr_attr $1)
+           else
+             match get_non_ptr_attr $1 with
+               Some attr -> Ast.PTVal($2, attr)
+             | None -> failwithf "unexpected pointer attributes for `%s'" (Ast.get_tystr $2)
       else
         fun is_ary ->
           if is_ary then Ast.PTPtr($2, get_ptr_attr [])
-          else  Ast.PTVal $2
+          else  Ast.PTVal($2, Ast.default_non_ptr_attr)
     }
   | all_type {
     match $1 with
@@ -390,7 +409,7 @@ param_type: attr_block all_type {
     | _         ->
       fun is_ary ->
         if is_ary then Ast.PTPtr($1, get_ptr_attr [])
-        else  Ast.PTVal $1
+        else  Ast.PTVal($1, Ast.default_non_ptr_attr)
     }
   | attr_block Tconst type_spec pointer {
       let attr = get_ptr_attr $1
@@ -551,7 +570,7 @@ parameter_def: param_type declarator {
     let pt = $1 (Ast.is_array $2) in
     let is_void =
       match pt with
-          Ast.PTVal v -> v = Ast.Void
+          Ast.PTVal(v, _) -> v = Ast.Void
         | _           -> false
     in
       if is_void then

--- a/sdk/edger8r/linux/Parser.mly
+++ b/sdk/edger8r/linux/Parser.mly
@@ -390,7 +390,7 @@ param_type: attr_block all_type {
             (* thinking about 'user_defined_type var[4]' *)
             fun is_ary ->
             if is_ary then Ast.PTPtr($2, attr)
-            else failwithf "`%s' is considerred plain type but decorated with pointer attributes" s
+            else failwithf "`%s' is considered a plain type but decorated with pointer attributes" s
         | _ ->
            fun is_ary ->
            if is_ary then Ast.PTPtr($2, get_ptr_attr $1)


### PR DESCRIPTION
This PR adds an attribute `enclave_id` to the edl, that passes the enclave's ID to the ocall:

```
enclave {
    trusted {
        public void thello();
    };
    untrusted {
        void uhello([enclave_id] uint64_t enclave_id, [in, string] const char *name);
    };
};
```
for `uhello` will generate
tmp_u.h:
```
(...)
void SGX_UBRIDGE(SGX_NOCONVENTION, uhello, (uint64_t enclave_id, const char* name));
(...)
```
tmp_t.h:
```
(...)
sgx_status_t SGX_CDECL uhello(const char* name);
(...)
```
automatically passing the enclave id.

There may be better ways of doing this (e.g. always pass the ID), but I was trying to make the changes backwards compatible. 