### PR TITLE
Sign tool: Added command line option to save enclave hash to a file

### DIFF
--- a/sdk/sign_tool/SignTool/sign_tool.cpp
+++ b/sdk/sign_tool/SignTool/sign_tool.cpp
@@ -1199,6 +1199,7 @@ int main(int argc, char* argv[])
         if(fwrite(enclave_hash, sizeof(enclave_hash), 1, fp) != 1)
         {
             se_trace(SE_TRACE_ERROR, OVERALL_ERROR);
+            fclose(fp);
             goto clear_return;
         }
         fclose(fp);

--- a/sdk/sign_tool/SignTool/util_st.h
+++ b/sdk/sign_tool/SignTool/util_st.h
@@ -59,7 +59,9 @@
     "   -ignore-rel-error   By default, sgx_sign provides an error for enclaves with\n" \
     "                       text relocations. You can ignore the error and continue signing\n" \
     "                       by providing this option. But it is recommended you eliminate the\n" \
-    "                       text relocations instead of bypassing the error with this option.\n"
+    "                       text relocations instead of bypassing the error with this option\n" \
+    "   -hash               Specify a file to write enclave hash to\n" \
+    "                       It is an option for \"sign\" and \"gendata\".\n"
 
 // General error message
 #define OVERALL_ERROR                       "Error happened while signing the enclave.\n"


### PR DESCRIPTION
Since there seems to be no convenient way to get enclave's MRENCLAVE value during the build process, this patch adds such option to the signing tool (-hash <hash file path>).

Signed-off-by: Rafal Wojdyla <omeg@invisiblethingslab.com>