### PR TITLE
 Expose an internal error on enclave_create ioctl interrupt.

### DIFF
--- a/common/inc/sgx_error.h
+++ b/common/inc/sgx_error.h
@@ -103,6 +103,8 @@ typedef enum _status_t
     SGX_ERROR_FILE_FLUSH_FAILED             = SGX_MK_ERROR(0x7008),	/* fflush operation (to disk) failed (only used when no EXXX is returned) */
     SGX_ERROR_FILE_CLOSE_FAILED             = SGX_MK_ERROR(0x7009),	/* fclose operation (to disk) failed (only used when no EXXX is returned) */
 
+    SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED = SGX_MK_ERROR(0xF001), /* The ioctl for enclave_create unexpectedly failed with EINTR. */
+
 } sgx_status_t;
 
 #endif

--- a/psw/urts/linux/enclave_creator_hw.cpp
+++ b/psw/urts/linux/enclave_creator_hw.cpp
@@ -144,6 +144,9 @@ int EnclaveCreatorHW::create_enclave(secs_t *secs, sgx_enclave_id_t *enclave_id,
     int ret = ioctl(m_hdevice, SGX_IOC_ENCLAVE_CREATE, &param);
     if(ret) 
     {
+        if(ret == -1 && errno == EINTR) {
+            return SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED;  // Allow the user to retry.
+        }
         SE_TRACE(SE_TRACE_WARNING, "\nSGX_IOC_ENCLAVE_CREATE failed: errno = %d\n", errno);
         return error_driver2urts(ret);
     }


### PR DESCRIPTION
This is an issue and PR rolled into one.

An enclave project I'm working on is getting to a semi-complicated state where the enclave .so file is about 15MiB. After a recent patch that added use of EGETKEY (red herring?), we started getting a 60% failure rate from sgx_create_enclave instead of 0%. I traced that to the ioctl call in create_enclave, where the call is failing with errno == EINTR. There is no error checking in the psw, so this patch adds a check-and-retry loop to try up to 5 times before failing with SGX_ERROR_DEVICE_BUSY. The error_driver2utrs function did not understand the -1 coming from the failing ioctl, so sgx_create_enclave was returning a less helpful SGX_ERROR_UNEXPECTED.

I don't have a small repro, and I think this is more of a band-aid solution than a real one. I thought maybe 15MiB is too big for ECREATE to validate in its time window, so I made a random enclave generator that links in /dev/urandom bytes converted through objcopy, and fiddled the enclave size up to many times our 15MiB. The sgx_enclave_create call never failed, so size can't be the only factor here.

I looked in the driver code and saw that the ioctl dispatch on enclave_create does not return EINTR, so it has to be the leaf instruction itself getting interrupted. Any clue as to why we would witness such a high failure rate?