### PR TITLE
Fix compatibility with OpenSSL 1.1.0.

### DIFF
--- a/sdk/sign_tool/SignTool/openssl_compat.cpp
+++ b/sdk/sign_tool/SignTool/openssl_compat.cpp
@@ -1,0 +1,16 @@
+#include <openssl/engine.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+void RSA_get0_key(const RSA *r,
+                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+{
+    if (n != NULL)
+        *n = r->n;
+    if (e != NULL)
+        *e = r->e;
+    if (d != NULL)
+        *d = r->d;
+}
+
+#endif

--- a/sdk/sign_tool/SignTool/openssl_compat.h
+++ b/sdk/sign_tool/SignTool/openssl_compat.h
@@ -1,0 +1,11 @@
+#ifndef _OPENSSL_COMPAT_H_
+#define _OPENSSL_COMPAT_H_
+
+#include <openssl/engine.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+void RSA_get0_key(const RSA *r,
+                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);
+
+#endif
+#endif

--- a/sdk/sign_tool/SignTool/parse_key_file.cpp
+++ b/sdk/sign_tool/SignTool/parse_key_file.cpp
@@ -40,6 +40,7 @@
 #include "parse_key_file.h"
 #include "se_trace.h"
 #include "util_st.h"
+#include "openssl_compat.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -99,14 +100,17 @@ bool parse_key_file(int mode, const char *key_path, RSA **prsa, int *pkey_type)
         return false;
     }
 
+    const BIGNUM *e = NULL, *n = NULL;
+    RSA_get0_key(rsa, &n, &e, NULL);
+
     // Check the key size and exponent
-    if(BN_num_bytes(rsa->n) != N_SIZE_IN_BYTES)
+    if(BN_num_bytes(n) != N_SIZE_IN_BYTES)
     {
         se_trace(SE_TRACE_ERROR, INVALID_KEYSIZE_ERROR);
         RSA_free(rsa);
         return false;
     }
-    char *p = BN_bn2dec(rsa->e);
+    char *p = BN_bn2dec(e);
     if(memcmp(p, "3", 2))
     {
         se_trace(SE_TRACE_ERROR, INVALID_EXPONENT_ERROR);

--- a/sdk/simulation/urtssim/enclave_creator_sim.cpp
+++ b/sdk/simulation/urtssim/enclave_creator_sim.cpp
@@ -61,7 +61,9 @@ static void cleanup_openssl(void)
 {
     EVP_cleanup();
     CRYPTO_cleanup_all_ex_data();
-    ERR_remove_thread_state(NULL);
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+        ERR_remove_thread_state(NULL);
+    #endif
     ERR_free_strings();
 }
 


### PR DESCRIPTION
Based on `OPENSSL_VERSION_NUMBER`, does the following:
 - Remove `ERR_remove_thread_state` see [here](https://www.openssl.org/docs/man1.1.0/crypto/ERR_remove_state.html)
 - Add compatibility layer as described [here](https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes#Compatibility_Layer)

Fixes #189.