### PR TITLE
Removes errno_t uses since it's painful to use in some toolchains.

### DIFF
--- a/SampleCode/RemoteAttestation/service_provider/ecp.cpp
+++ b/SampleCode/RemoteAttestation/service_provider/ecp.cpp
@@ -40,7 +40,7 @@
 
 #define MAC_KEY_SIZE       16
 
-errno_t memcpy_s(
+int memcpy_s(
     void *dest,
     size_t numberOfElements,
     const void *src,

--- a/SampleCode/RemoteAttestation/service_provider/ecp.h
+++ b/SampleCode/RemoteAttestation/service_provider/ecp.h
@@ -61,12 +61,7 @@ typedef uint8_t sample_ec_key_128bit_t[16];
 extern "C" {
 #endif
 
-
-#ifndef _ERRNO_T_DEFINED
-#define _ERRNO_T_DEFINED
-typedef int errno_t;
-#endif
-errno_t memcpy_s(void *dest, size_t numberOfElements, const void *src,
+int memcpy_s(void *dest, size_t numberOfElements, const void *src,
                  size_t count);
 
 
@@ -111,4 +106,3 @@ bool verify_cmac128(
 #endif
 
 #endif
-

--- a/common/inc/internal/se_memcpy.h
+++ b/common/inc/internal/se_memcpy.h
@@ -37,12 +37,7 @@
 
 /* memcpy_s always return 0 under Linux */
 
-#ifndef _ERRNO_T_DEFINED
-#define _ERRNO_T_DEFINED
-typedef int errno_t;
-#endif
-
-static inline errno_t memcpy_s(void *dest, size_t numberOfElements, const void *src, size_t count)
+static inline int memcpy_s(void *dest, size_t numberOfElements, const void *src, size_t count)
 {
     if(numberOfElements<count)
         return -1;

--- a/common/inc/internal/se_stdio.h
+++ b/common/inc/internal/se_stdio.h
@@ -75,9 +75,9 @@ static inline int _snprintf_s(char *dst_buf, size_t size_in_bytes, size_t max_co
     return cnt;
 }
 
-static inline errno_t fopen_s(FILE **f, const char *filename, const char *mode)
+static inline int fopen_s(FILE **f, const char *filename, const char *mode)
 {
-    errno_t err = 0;
+    int err = 0;
     *f = fopen(filename, mode);
     if(*f==NULL){
         err = -1;

--- a/common/inc/internal/se_string.h
+++ b/common/inc/internal/se_string.h
@@ -35,20 +35,14 @@
 #include "se_memcpy.h"
 #include <string.h>
 
-
-#ifndef _ERRNO_T_DEFINED
-#define _ERRNO_T_DEFINED
-typedef int errno_t;
-#endif
-
-static inline errno_t strcat_s(char *dst, size_t max_size, const char *src)
+static inline int strcat_s(char *dst, size_t max_size, const char *src)
 {
     if(strlen(dst)+strlen(src)+1>max_size)return -1;
     strcat(dst, src);
     return 0;
 }
 
-static inline errno_t strcpy_s(char *dst, size_t max_size, const char *src)
+static inline int strcpy_s(char *dst, size_t max_size, const char *src)
 {
     if(strnlen(src, max_size)+1>max_size)return -1;
     strcpy(dst, src);
@@ -56,7 +50,7 @@ static inline errno_t strcpy_s(char *dst, size_t max_size, const char *src)
 }
 
 #define _strnicmp strncasecmp
-static inline errno_t strncat_s(char *dst, size_t max_size, const char *src, size_t max_count)
+static inline int strncat_s(char *dst, size_t max_size, const char *src, size_t max_count)
 {
     size_t len = strnlen(src,max_count);
     len+=strnlen(dst, max_size)+1;

--- a/common/inc/tlibc/mbusafecrt.h
+++ b/common/inc/tlibc/mbusafecrt.h
@@ -29,37 +29,37 @@ typedef wchar_t WCHAR;
     extern "C" {
 #endif
 
-extern errno_t strcat_s( char* ioDest, size_t inDestBufferSize, const char* inSrc );
-extern errno_t wcscat_s( WCHAR* ioDest, size_t inDestBufferSize, const WCHAR* inSrc );
+extern int strcat_s( char* ioDest, size_t inDestBufferSize, const char* inSrc );
+extern int wcscat_s( WCHAR* ioDest, size_t inDestBufferSize, const WCHAR* inSrc );
 
-extern errno_t strncat_s( char* ioDest, size_t inDestBufferSize, const char* inSrc, size_t inCount );
-extern errno_t wcsncat_s( WCHAR* ioDest, size_t inDestBufferSize, const WCHAR* inSrc, size_t inCount );
+extern int strncat_s( char* ioDest, size_t inDestBufferSize, const char* inSrc, size_t inCount );
+extern int wcsncat_s( WCHAR* ioDest, size_t inDestBufferSize, const WCHAR* inSrc, size_t inCount );
 
-extern errno_t strcpy_s( char* outDest, size_t inDestBufferSize, const char* inSrc );
-extern errno_t wcscpy_s( WCHAR* outDest, size_t inDestBufferSize, const WCHAR* inSrc );
+extern int strcpy_s( char* outDest, size_t inDestBufferSize, const char* inSrc );
+extern int wcscpy_s( WCHAR* outDest, size_t inDestBufferSize, const WCHAR* inSrc );
 
-extern errno_t strncpy_s( char* outDest, size_t inDestBufferSize, const char* inSrc, size_t inCount );
-extern errno_t wcsncpy_s( WCHAR* outDest, size_t inDestBufferSize, const WCHAR* inSrc, size_t inCount );
+extern int strncpy_s( char* outDest, size_t inDestBufferSize, const char* inSrc, size_t inCount );
+extern int wcsncpy_s( WCHAR* outDest, size_t inDestBufferSize, const WCHAR* inSrc, size_t inCount );
 
 extern char* strtok_s( char* inString, const char* inControl, char** ioContext );
 extern WCHAR* wcstok_s( WCHAR* inString, const WCHAR* inControl, WCHAR** ioContext );
 
 extern size_t wcsnlen( const WCHAR* inString, size_t inMaxSize );
 
-extern errno_t _itoa_s( int inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
-extern errno_t _itow_s( int inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _itoa_s( int inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _itow_s( int inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 
-extern errno_t _ltoa_s( long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
-extern errno_t _ltow_s( long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _ltoa_s( long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _ltow_s( long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 
-extern errno_t _ultoa_s( unsigned long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
-extern errno_t _ultow_s( unsigned long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _ultoa_s( unsigned long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _ultow_s( unsigned long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 
-extern errno_t _i64toa_s( long long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
-extern errno_t _i64tow_s( long long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _i64toa_s( long long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _i64tow_s( long long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 
-extern errno_t _ui64toa_s( unsigned long long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
-extern errno_t _ui64tow_s( unsigned long long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _ui64toa_s( unsigned long long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern int _ui64tow_s( unsigned long long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 
 extern int sprintf_s( char *string, size_t sizeInBytes, const char *format, ... );
 extern int swprintf_s( WCHAR *string, size_t sizeInWords, const WCHAR *format, ... );
@@ -73,8 +73,8 @@ extern int _vsnprintf_s( char* string, size_t sizeInBytes, size_t count, const c
 extern int _vswprintf_s( WCHAR* string, size_t sizeInWords, const WCHAR* format, va_list arglist );
 extern int _vsnwprintf_s( WCHAR* string, size_t sizeInWords, size_t count, const WCHAR* format, va_list arglist );
 
-extern errno_t memcpy_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
-extern errno_t memmove_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
+extern int memcpy_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
+extern int memmove_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
 
 #ifdef __cplusplus
     }

--- a/common/inc/tlibc/string.h
+++ b/common/inc/tlibc/string.h
@@ -43,11 +43,6 @@ typedef __size_t    size_t;
 #define _SIZE_T_DEFINED_
 #endif
 
-#ifndef _ERRNO_T_DEFINED
-#define _ERRNO_T_DEFINED
-typedef int errno_t;
-#endif
-
 #ifndef NULL
 #ifdef __cplusplus
 #define NULL    0
@@ -79,7 +74,7 @@ char * _TLIBC_CDECL_ strstr(const char *, const char *);
 char * _TLIBC_CDECL_ strtok(char *, const char *);
 size_t _TLIBC_CDECL_ strxfrm(char *, const char *, size_t);
 size_t _TLIBC_CDECL_ strlcpy(char *, const char *, size_t);
-errno_t _TLIBC_CDECL_ memset_s(void *s, size_t smax, int c, size_t n);
+int _TLIBC_CDECL_ memset_s(void *s, size_t smax, int c, size_t n);
 
 /*
  * Deprecated C99.

--- a/external/tinyxml2/tinyxml2.cpp
+++ b/external/tinyxml2/tinyxml2.cpp
@@ -1937,7 +1937,7 @@ static FILE* callfopen( const char* filepath, const char* mode )
     TIXMLASSERT( mode );
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
     FILE* fp = 0;
-    errno_t err = fopen_s( &fp, filepath, mode );
+    int err = fopen_s( &fp, filepath, mode );
     if ( err ) {
         return 0;
     }

--- a/sdk/tkey_exchange/simple_vector.cpp
+++ b/sdk/tkey_exchange/simple_vector.cpp
@@ -63,7 +63,7 @@ uint32_t vector_size(const simple_vector* v)
 
 //push a pointer to the end of the vector
 //return 0 if success, return 1 if memory malloc failure.
-errno_t vector_push_back(simple_vector* v, const void* data)
+int vector_push_back(simple_vector* v, const void* data)
 {
     if (v)
     {
@@ -97,7 +97,7 @@ errno_t vector_push_back(simple_vector* v, const void* data)
 
 //get the item pointer in the vector
 //return 0 if success, return 1 if index is out of range or data pointer is invalid.
-errno_t vector_get(const simple_vector* v, uint32_t index, void** data)
+int vector_get(const simple_vector* v, uint32_t index, void** data)
 {
     if (!v || index >= v->size || !data)
         return 1;
@@ -111,7 +111,7 @@ errno_t vector_get(const simple_vector* v, uint32_t index, void** data)
 
 //set the pointer in the vector
 //return 0 if success, return 1 if index is out of range.
-errno_t vector_set(simple_vector* v, uint32_t index, const void* data)
+int vector_set(simple_vector* v, uint32_t index, const void* data)
 {
     if (!v || index >= v->size)
         return 1;

--- a/sdk/tkey_exchange/simple_vector.h
+++ b/sdk/tkey_exchange/simple_vector.h
@@ -53,13 +53,13 @@ void vector_init(simple_vector* vector);
 uint32_t vector_size(const simple_vector* vector);
 
 //insert an element to the end of simple_vector, the element can only be pointer
-errno_t vector_push_back(simple_vector* vector, const void* data);
+int vector_push_back(simple_vector* vector, const void* data);
 
 //get an element
-errno_t vector_get(const simple_vector* v, uint32_t index, void** data);
+int vector_get(const simple_vector* v, uint32_t index, void** data);
 
 //set an element content
-errno_t vector_set(simple_vector* v, uint32_t index, const void* data);
+int vector_set(simple_vector* v, uint32_t index, const void* data);
 
 //free the simple_vector allocated memory
 void vector_free(simple_vector* vector);

--- a/sdk/tkey_exchange/tkey_exchange.cpp
+++ b/sdk/tkey_exchange/tkey_exchange.cpp
@@ -675,7 +675,7 @@ sgx_status_t sgx_ra_init_ex(
     //if there is a empty slot, use it
     if (first_empty >= 0)
     {
-        errno_t vret = vector_set(&g_ra_db, first_empty, new_item);
+        int vret = vector_set(&g_ra_db, first_empty, new_item);
         UNUSED(vret);
         assert(vret == 0);
         *p_context = first_empty;

--- a/sdk/tlibc/string/memset_s.c
+++ b/sdk/tlibc/string/memset_s.c
@@ -33,7 +33,6 @@
 
 #include <sys/cdefs.h>
 
-#define __STDC_WANT_LIB_EXT1__ 1
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
@@ -47,10 +46,10 @@ static void * (* const volatile __memset_vp)(void *, int, size_t)
 
 #undef memset_s /* in case it was defined as a macro */
 
-errno_t
+int
 memset_s(void *s, size_t smax, int c, size_t n)
 {
-    errno_t err = 0;
+    int err = 0;
 
     if (s == NULL) {
         err = EINVAL;

--- a/sdk/tlibcxx/src/random.cpp
+++ b/sdk/tlibcxx/src/random.cpp
@@ -136,7 +136,7 @@ unsigned
 random_device::operator()()
 {
     unsigned r;
-    errno_t err = rand_s(&r);
+    int err = rand_s(&r);
     if (err)
         __throw_system_error(err, "random_device rand_s failed.");
     return r;

--- a/sdk/tlibcxx/src/support/win32/support.cpp
+++ b/sdk/tlibcxx/src/support/win32/support.cpp
@@ -121,8 +121,8 @@ size_t wcsnrtombs( char *__restrict dst, const wchar_t **__restrict src,
     size_t dest_converted = 0;
     size_t dest_remaining = dst_size_bytes;
     size_t char_size = 0;
-    const errno_t no_error = ( errno_t) 0;
-    errno_t result = ( errno_t ) 0;
+    const int no_error = ( int) 0;
+    int result = ( int ) 0;
     bool have_result = false;
     bool terminator_found = false;
 

--- a/sdk/tsafecrt/pal/src/safecrt/mbusafecrt.c
+++ b/sdk/tsafecrt/pal/src/safecrt/mbusafecrt.c
@@ -162,7 +162,7 @@ int _ungetwc_nolock( char16_t inChar, miniFILE* inStream )
 // taken from output.inl
 #define FL_ALTERNATE  0x00080   /* alternate form requested */
 
-errno_t _safecrt_cfltcvt(double *arg, char *buffer, size_t sizeInBytes, int type, int precision, int flags)
+int _safecrt_cfltcvt(double *arg, char *buffer, size_t sizeInBytes, int type, int precision, int flags)
 {
     char format[FORMATSIZE];
     size_t formatlen = 0;

--- a/sdk/tsafecrt/pal/src/safecrt/mbusafecrt_internal.h
+++ b/sdk/tsafecrt/pal/src/safecrt/mbusafecrt_internal.h
@@ -81,7 +81,7 @@ int _getwc_nolock( miniFILE* inStream );
 int _ungetc_nolock( char inChar, miniFILE* inStream );
 int _ungetwc_nolock( char16_t inChar, miniFILE* inStream );
 #endif
-errno_t _safecrt_cfltcvt(double *arg, char *buffer, size_t sizeInBytes, int type, int precision, int flags);
+int _safecrt_cfltcvt(double *arg, char *buffer, size_t sizeInBytes, int type, int precision, int flags);
 #ifndef _LIBSAFECRT_SGX_CONFIG
 void _safecrt_fassign(int flag, void* argument, char * number );
 void _safecrt_wfassign(int flag, void* argument, char16_t * number );

--- a/sdk/tsafecrt/pal/src/safecrt/memcpy_s.c
+++ b/sdk/tsafecrt/pal/src/safecrt/memcpy_s.c
@@ -50,7 +50,7 @@
 *
 *******************************************************************************/
 
-errno_t __cdecl memcpy_s(
+int __cdecl memcpy_s(
     void * dst,
     size_t sizeInBytes,
     const void * src,

--- a/sdk/tsafecrt/pal/src/safecrt/tcscat_s.inl
+++ b/sdk/tsafecrt/pal/src/safecrt/tcscat_s.inl
@@ -14,7 +14,7 @@
 ****/
 
 _FUNC_PROLOGUE
-errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC)
+int __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC)
 {
     _CHAR *p;
     size_t available;

--- a/sdk/tsafecrt/pal/src/safecrt/tcscpy_s.inl
+++ b/sdk/tsafecrt/pal/src/safecrt/tcscpy_s.inl
@@ -14,7 +14,7 @@
 ****/
 
 _FUNC_PROLOGUE
-errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC)
+int __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC)
 {
     _CHAR *p;
     size_t available;

--- a/sdk/tsafecrt/pal/src/safecrt/tcsncat_s.inl
+++ b/sdk/tsafecrt/pal/src/safecrt/tcsncat_s.inl
@@ -14,7 +14,7 @@
 ****/
 
 _FUNC_PROLOGUE
-errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC, size_t _COUNT)
+int __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC, size_t _COUNT)
 {
     _CHAR *p;
     size_t available;

--- a/sdk/tsafecrt/pal/src/safecrt/tcsncpy_s.inl
+++ b/sdk/tsafecrt/pal/src/safecrt/tcsncpy_s.inl
@@ -14,7 +14,7 @@
 ****/
 
 _FUNC_PROLOGUE
-errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC, size_t _COUNT)
+int __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC, size_t _COUNT)
 {
     _CHAR *p;
     size_t available;

--- a/sdk/tsafecrt/pal/src/safecrt/vsprintf.c
+++ b/sdk/tsafecrt/pal/src/safecrt/vsprintf.c
@@ -164,7 +164,7 @@ int __cdecl _vsnprintf_s (
         )
 {
     int retvalue = -1;
-    errno_t save_errno = 0;
+    int save_errno = 0;
 
     /* validation section */
     _VALIDATE_RETURN(format != NULL, EINVAL, -1);

--- a/sdk/tsafecrt/pal/src/safecrt/vswprint.c
+++ b/sdk/tsafecrt/pal/src/safecrt/vswprint.c
@@ -184,7 +184,7 @@ int __cdecl _vsnwprintf_s (
         )
 {
     int retvalue = -1;
-    errno_t save_errno = 0;
+    int save_errno = 0;
 
     /* validation section */
     _VALIDATE_RETURN(format != NULL, EINVAL, -1);

--- a/sdk/tsafecrt/pal/src/safecrt/wcslen_s.c
+++ b/sdk/tsafecrt/pal/src/safecrt/wcslen_s.c
@@ -48,7 +48,7 @@ size_t __cdecl wcsnlen(const char16_t *wcs, size_t maxsize)
     size_t n;
 
     /* Note that we do not check if s == NULL, because we do not
-     * return errno_t...
+     * return errno_t;...
      */
 
     for (n = 0; n < maxsize && *wcs; n++, wcs++)

--- a/sdk/tsafecrt/pal/src/safecrt/xtox_s.inl
+++ b/sdk/tsafecrt/pal/src/safecrt/xtox_s.inl
@@ -60,7 +60,7 @@
 *
 *Exit:
 *       Fills in space pointed to by buf with string result.
-*       Returns the errno_t: err != 0 means that something went wrong, and
+*       Returns the int: err != 0 means that something went wrong, and
 *       an empty string (buf[0] = 0) is returned.
 *
 *Exceptions:
@@ -71,7 +71,7 @@
 
 /* helper routine that does the main job. */
 #ifdef _SECURE_ITOA
-errno_t __stdcall xtox_s
+int __stdcall xtox_s
         (
         unsigned long val,
         TCHAR *buf,
@@ -161,14 +161,14 @@ void __stdcall xtox
    and return pointer to buffer. */
 
 #ifdef _SECURE_ITOA
-errno_t __cdecl _itox_s (
+int __cdecl _itox_s (
         int val,
         TCHAR *buf,
         size_t sizeInTChars,
         int radix
         )
 {
-        errno_t e = 0;
+        int e = 0;
 
         if (radix == 10 && val < 0)
             e = xtox_s((unsigned long)val, buf, sizeInTChars, (unsigned)radix, 1);
@@ -178,7 +178,7 @@ errno_t __cdecl _itox_s (
         return e;
 }
 
-errno_t __cdecl _ltox_s (
+int __cdecl _ltox_s (
         long val,
         TCHAR *buf,
         size_t sizeInTChars,
@@ -188,7 +188,7 @@ errno_t __cdecl _ltox_s (
         return xtox_s((unsigned long)val, buf, sizeInTChars, (unsigned)radix, (radix == 10 && val < 0));
 }
 
-errno_t __cdecl _ultox_s (
+int __cdecl _ultox_s (
         unsigned long val,
         TCHAR *buf,
         size_t sizeInTChars,
@@ -277,7 +277,7 @@ TCHAR * __cdecl _ultox (
 *
 *Exit:
 *       Fills in space pointed to by buf with string result.
-*       Returns the errno_t: err != 0 means that something went wrong, and
+*       Returns the int: err != 0 means that something went wrong, and
 *       an empty string (buf[0] = 0) is returned.
 *
 *Exceptions:
@@ -287,7 +287,7 @@ TCHAR * __cdecl _ultox (
 *******************************************************************************/
 
 #ifdef _SECURE_ITOA
-errno_t __fastcall x64tox_s
+int __fastcall x64tox_s
         (/* stdcall is faster and smaller... Might as well use it for the helper. */
         unsigned __int64 val,
         TCHAR *buf,
@@ -379,7 +379,7 @@ void __fastcall x64tox
 /* Actual functions just call conversion helper with neg flag set correctly,
    and return pointer to buffer. */
 
-errno_t __cdecl _i64tox_s (
+int __cdecl _i64tox_s (
         long long val,
         TCHAR *buf,
         size_t sizeInTChars,
@@ -389,7 +389,7 @@ errno_t __cdecl _i64tox_s (
         return x64tox_s((unsigned __int64)val, buf, sizeInTChars, (unsigned)radix, (radix == 10 && val < 0));
 }
 
-errno_t __cdecl _ui64tox_s (
+int __cdecl _ui64tox_s (
         unsigned long long val,
         TCHAR *buf,
         size_t sizeInTChars,


### PR DESCRIPTION
The C11 standard has errno_t as an optional addition which is not as widely supported as users of this SDK would hope.
Appendix K already defines errno_t as int, so this PR does the replacement.