### PR TITLE
Adds an API function to check if the enclave has crashed.

### DIFF
--- a/common/inc/sgx_trts.h
+++ b/common/inc/sgx_trts.h
@@ -74,6 +74,13 @@ int SGXAPI sgx_is_outside_enclave(const void *addr, size_t size);
 */
 sgx_status_t SGXAPI sgx_read_rand(unsigned char *rand, size_t length_in_bytes);
 
+/* sgx_is_enclave_crashed()
+ * Return Value:
+ *      1 - The global enclave state is crashed.
+ *      0 - The global enclave state is not crashed.
+ */
+int SGXAPI sgx_is_enclave_crashed(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sdk/trts/trts.cpp
+++ b/sdk/trts/trts.cpp
@@ -291,6 +291,11 @@ sgx_status_t sgx_read_rand(unsigned char *rand, size_t length_in_bytes)
     return SGX_SUCCESS;
 }
 
+int sgx_is_enclave_crashed()
+{
+  return get_enclave_state() == ENCLAVE_CRASHED;
+}
+
 extern uintptr_t __stack_chk_guard;
 int check_static_stack_canary(void *tcs)
 {
@@ -301,4 +306,3 @@ int check_static_stack_canary(void *tcs)
     }
     return 0;
 }
-

--- a/sdk/trts/trts_nsp.cpp
+++ b/sdk/trts/trts_nsp.cpp
@@ -73,7 +73,7 @@ static void init_stack_guard(void *tcs)
 
 extern "C" int enter_enclave(int index, void *ms, void *tcs, int cssa)
 {
-    if(get_enclave_state() == ENCLAVE_CRASHED)
+    if(sgx_is_enclave_crashed())
     {
         return SGX_ERROR_ENCLAVE_CRASHED;
     }


### PR DESCRIPTION
Since thread A in an enclave can't be preempted by thread B (which calls `abort()`), this API call allows for cooperation to shut down more gracefully. An OS may not tear down a process immediately, so it's useful for threads to periodically check if they're in an aborted state and shut down.