### PR TITLE
Adds includes to allow use of some typedefs when in pickier compilers.

### DIFF
--- a/common/inc/internal/se_atomic.h
+++ b/common/inc/internal/se_atomic.h
@@ -32,6 +32,7 @@
 #ifndef _SE_ATOMIC_H_
 #define _SE_ATOMIC_H_
 
+#include <stdint.h>
 
 inline uint32_t se_atomic_inc(volatile uint32_t *mem)
 {

--- a/psw/ae/aesm_service/source/upse/platform_info_blob.h
+++ b/psw/ae/aesm_service/source/upse/platform_info_blob.h
@@ -33,6 +33,7 @@
 #define _PLATFORM_INFO_BLOB_H_
 
 #include <stdint.h>
+#include "aeerror.h"
 #include "epid_pve_type.h"
 #include "sgx_tcrypto.h"
 


### PR DESCRIPTION
se_atomic uses uint32_t from stdint.h and platform_info_blob.h uses ae_error_t.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>