### PR TITLE
Add exception handler to edger8r.

### DIFF
--- a/sdk/edger8r/linux/Ast.ml
+++ b/sdk/edger8r/linux/Ast.ml
@@ -159,6 +159,7 @@ type func_decl = {
 type trusted_func = {
   tf_fdecl   : func_decl;
   tf_is_priv : bool;
+  tf_is_exception_handler : bool;
 }
 
 type untrusted_func = {

--- a/sdk/edger8r/linux/Lexer.mll
+++ b/sdk/edger8r/linux/Lexer.mll
@@ -79,6 +79,7 @@ rule tokenize = parse
   | "struct"     { Tstruct }
   | "union"      { Tunion }
   | "enum"       { Tenum }
+  | "exception_handler" { Texception_handler }
 
   (* specifier *)
   | "enclave"    { Tenclave }

--- a/sdk/edger8r/linux/Parser.mly
+++ b/sdk/edger8r/linux/Parser.mly
@@ -261,7 +261,7 @@ let check_ptr_attr (fd: Ast.func_decl) range =
 %token Tchar Tshort Tunsigned Tint Tfloat Tdouble
        Tint8 Tint16 Tint32 Tint64
        Tuint8 Tuint16 Tuint32 Tuint64
-       Tsizet Twchar Tvoid Tlong Tstruct Tunion Tenum
+       Tsizet Twchar Tvoid Tlong Tstruct Tunion Tenum Texception_handler
 %token Tenclave Tfrom Timport Ttrusted Tuntrusted Tallow Tpropagate_errno
 
 %start start_parsing
@@ -519,10 +519,15 @@ access_modifier: /* nothing */ { true }
   | Tpublic                    { false  }
   ;
 
+/* is exception_handler? Default to false. */
+exception_handler: /* nothing */ { false }
+  | Texception_handler           { true }
+  ;
+
 trusted_functions: /* nothing */          { [] }
-  | trusted_functions access_modifier func_def TSemicolon {
-      check_ptr_attr $3 (symbol_start_pos(), symbol_end_pos());
-      Ast.Trusted { Ast.tf_fdecl = $3; Ast.tf_is_priv = $2 } :: $1
+  | trusted_functions exception_handler access_modifier func_def TSemicolon {
+      check_ptr_attr $4 (symbol_start_pos(), symbol_end_pos());
+      Ast.Trusted { Ast.tf_fdecl = $4; Ast.tf_is_priv = $3; Ast.tf_is_exception_handler = $2 } :: $1
     }
   ;
 


### PR DESCRIPTION
Add a exception_handler to the edger8r. If any function in .edl file is marked
as "exception_handler", it should be set the "is_exception" field in the ecall
table. This is used for users to set their own exception, like signal
handler.