### PR TITLE
Fix red zone issue in continue_execution()

### DIFF
--- a/sdk/trts/linux/trts_pic.S
+++ b/sdk/trts/linux/trts_pic.S
@@ -552,8 +552,10 @@ DECLARE_LOCAL_FUNC continue_execution
     push    %xax                       # push xax
     mov     SE_WORDSIZE*1(%xcx), %xax
     push    %xax                       # push xcx
-    mov     SE_WORDSIZE*4(%xcx), %xax
-    sub     $(SE_WORDSIZE), %xax       # xax: xsp
+    mov     SE_WORDSIZE*4(%xcx), %xax  # xax: xsp 
+# x86_64 requires a 128-bytes red zone. We need to allocate buffer to avoid touching the red zone.
+    sub     $(SE_WORDSIZE + RED_ZONE_SIZE), %xax  # allocate buffer to skip the red zone (if any) and save the xip
+                                                  # RED_ZONE_SIZE: 0(i386), 128-bytes(x86_64) 
 
 # restore registers except xax, xcx, xsp
     mov     SE_WORDSIZE*2(%xcx), %xdx
@@ -589,4 +591,4 @@ DECLARE_LOCAL_FUNC continue_execution
     pop     %xcx                       # restore xcx
     pop     %xsp                       # xsp: xax
     xchg    %xax, %xsp
-    ret
+    ret     $(RED_ZONE_SIZE)           # pop xip and red zone (if any)

--- a/sdk/trts/linux/trts_pic.h
+++ b/sdk/trts/linux/trts_pic.h
@@ -39,6 +39,7 @@
 
 #include "linux/linux-regs.h"
 #include "rts_cmd.h"
+#include "trts_shared_constants.h"
 
 #define SE_GUARD_PAGE_SIZE 0x10000
 
@@ -55,7 +56,6 @@
 #define SGX_ERROR_ENCLAVE_CRASHED     0x000001006 // enclave is crashed
 #define SGX_ERROR_STACK_OVERRUN       0x000001009 // enclave is running out of stack
 
-#define STATIC_STACK_SIZE   688
 
 /* Thread Data
  * c.f. data structure defintion for thread_data_t in `rts.h'.

--- a/sdk/trts/trts_shared_constants.h
+++ b/sdk/trts/trts_shared_constants.h
@@ -28,52 +28,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-#ifndef TRTS_INTERNAL_H
-#define TRTS_INTERNAL_H
 
-#include "util.h"
-#include "trts_shared_constants.h"
+/*
+ * trts_shared_constants.h:
+ *    Defines constants shared in C/C++ code and assembly code.
+ */
 
-#define TD2TCS(td) ((const void *)(((thread_data_t*)(td))->stack_base_addr + (size_t)STATIC_STACK_SIZE + (size_t)SE_GUARD_PAGE_SIZE))
-#define TCS2CANARY(addr)    ((size_t *)((size_t)(addr)-(size_t)SE_GUARD_PAGE_SIZE-(size_t)STATIC_STACK_SIZE+sizeof(size_t)))
-
-typedef struct {
-    const void     *ecall_addr;
-    uint8_t         is_priv;
-} ecall_addr_t;
-
-typedef struct {
-    size_t          nr_ecall;
-    ecall_addr_t    ecall_table[1];
-} ecall_table_t;
-
-typedef struct {
-    size_t  nr_ocall;
-    uint8_t entry_table[1];
-} entry_table_t;
+#ifndef _TRTS_SHARED_CONSTANTS_H_
+#define _TRTS_SHARED_CONSTANTS_H_
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-extern ecall_table_t g_ecall_table;
-extern entry_table_t g_dyn_entry_table;
 
-int lock_enclave();
-void *get_enclave_base();
-int get_enclave_state();
-void set_enclave_state(int state);
-
-sgx_status_t do_init_thread(void *tcs);
-sgx_status_t do_init_enclave(void *ms, void *tcs);
-sgx_status_t do_ecall(int index, void *ms, void *tcs);
-sgx_status_t do_oret(void *ms);
-sgx_status_t trts_handle_exception(void *tcs);
-sgx_status_t do_ecall_add_thread(void *ms, void *tcs);
-sgx_status_t do_uninit_enclave(void *tcs);
-int check_static_stack_canary(void *tcs);
-#ifdef __cplusplus
-}
+#if defined(__x86_64) || defined(__x86_64__)
+#define RED_ZONE_SIZE   128
+#else
+#define RED_ZONE_SIZE   0
 #endif
 
+
+#define STATIC_STACK_SIZE   688
+
+
 #endif
+

--- a/sdk/trts/trts_veh.cpp
+++ b/sdk/trts/trts_veh.cpp
@@ -48,6 +48,8 @@
 #include "trts_inst.h"
 #include "util.h"
 #include "trts_util.h"
+#include "trts_shared_constants.h"
+
 
 typedef struct _handler_node_t
 {
@@ -337,10 +339,9 @@ extern "C" sgx_status_t trts_handle_exception(void *tcs)
     }
 
     size = 0;
-#ifdef SE_GNU64
-    size += 128; // x86_64 requires a 128-bytes red zone, which begins directly
-                 // after the return addr and includes func's arguments
-#endif
+    // x86_64 requires a 128-bytes red zone, which begins directly
+    // after the return addr and includes func's arguments
+    size += RED_ZONE_SIZE;
 
     // decrease the stack to give space for info
     size += sizeof(sgx_exception_info_t);


### PR DESCRIPTION
Also put some macros shared in C/C++ and assembly code to one header file.

Signed-off-by: Zhang Lili Z <lili.z.zhang@intel.com>