### PR TITLE
Annotate fallthroughs for -Wimplicit-fallthrough.

### DIFF
--- a/external/tinyxml2/tinyxml2.cpp
+++ b/external/tinyxml2/tinyxml2.cpp
@@ -431,7 +431,7 @@ void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
             TINYXML_FALLTHROUGH_INTENDED;
-         case 1:
+        case 1:
             --output;
             *output = (char)(input | FIRST_BYTE_MARK[*length]);
             break;

--- a/external/tinyxml2/tinyxml2.cpp
+++ b/external/tinyxml2/tinyxml2.cpp
@@ -32,6 +32,14 @@ distribution.
 #   include <cstdarg>
 #endif
 
+#if defined(__clang__) && defined(__has_warning)
+#if __has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough")
+#define TINYXML_FALLTHROUGH_INTENDED [[clang::fallthrough]]
+#endif
+#elif defined(__GNUC__) && __GNUC__ >= 7
+#define TINYXML_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
+#endif
+
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
 	// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
 	/*int _snprintf_s(
@@ -409,18 +417,18 @@ void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length
             --output;
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            /* fallthrough */
+            TINYXML_FALLTHROUGH_INTENDED;
         case 3:
             --output;
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            /* fallthrough */
+            TINYXML_FALLTHROUGH_INTENDED;
         case 2:
             --output;
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            /* fallthrough */
-        case 1:
+            TINYXML_FALLTHROUGH_INTENDED;
+         case 1:
             --output;
             *output = (char)(input | FIRST_BYTE_MARK[*length]);
             break;

--- a/external/tinyxml2/tinyxml2.cpp
+++ b/external/tinyxml2/tinyxml2.cpp
@@ -39,6 +39,9 @@ distribution.
 #elif defined(__GNUC__) && __GNUC__ >= 7
 #define TINYXML_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
 #endif
+#ifndef TINYXML_FALLTHROUGH_INTENDED
+#define TINYXML_FALLTHROUGH_INTENDED do { } while(0)
+#endif
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
 	// Microsoft Visual Studio, version 2005 and higher. Not WinCE.


### PR DESCRIPTION
GCC 7 and clang have an analysis that warns against implicit fallthroughs. This PR adds an annotation to make the fallthroughs explicit. C++17 adds [[fallthrough]] as a statement annotation, but until then, clang- and gcc-specific annotations will have to do.