### PR TITLE
add -Wno-unused-parameter to protobufs

### DIFF
--- a/psw/uae_service/linux/Makefile
+++ b/psw/uae_service/linux/Makefile
@@ -57,7 +57,7 @@ INCLUDE += -I$(LINUX_EXTERNAL_DIR)/epid-sdk-3.0.0    \
            -I$(IPC_COMMON_PROTO_DIR) \
            -I$(LINUX_PSW_DIR)/ae/aesm_service/source
 
-CXXFLAGS += -fPIC -Werror -g -DPROTOBUF_INLINE_NOT_IN_HEADERS=0
+CXXFLAGS += -fPIC -Werror -Wno-unused-parameter -g -DPROTOBUF_INLINE_NOT_IN_HEADERS=0
 
 EXTERNAL_LIB += -lprotobuf 
  


### PR DESCRIPTION
Add -Wno-unused-parameter to avoid warnings on protobuf build.
Signed-off-by: Yu Yuan <yuan.yu@intel.com>