### PR TITLE
Update supported OS version in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@ Build the Intel(R) SGX SDK and Intel(R) SGX PSW Package
 -------------------------------------------------------
 ### Prerequisites:
 - Ensure that you have one of the following required operating systems:  
-  * Ubuntu\* 16.04.3 LTS Desktop 64bits
-  * Ubuntu\* 16.04.3 LTS Server 64bits
+  * Ubuntu\* 16.04 LTS Desktop 64bits
+  * Ubuntu\* 16.04 LTS Server 64bits
   * Red Hat Enterprise Linux Server release 7.4 64bits
   * CentOS 7.4.1708 64bits
   * Fedora 27 Server 64bits
-  * Fedora 27 Workstation 64bits
   * SUSE Linux Enterprise Server 12 64bits
 
 - Use the following command(s) to install the required tools to build the Intel(R) SGX SDK:  
@@ -143,12 +142,11 @@ Install the Intel(R) SGX SDK
 ------------------------
 ### Prerequisites
 - Ensure that you have one of the following operating systems:  
-  * Ubuntu\* 16.04.3 LTS Desktop 64bits
-  * Ubuntu\* 16.04.3 LTS Server 64bits
+  * Ubuntu\* 16.04 LTS Desktop 64bits
+  * Ubuntu\* 16.04 LTS Server 64bits
   * Red Hat Enterprise Linux Server release 7.4 64bits
   * CentOS 7.4.1708 64bits
   * Fedora 27 Server 64bits
-  * Fedora 27 Workstation 64bits
   * SUSE Linux Enterprise Server 12 64bits
 - Use the following command to install the required tool to use Intel(R) SGX SDK:
   * On Ubuntu 16.04:
@@ -207,12 +205,11 @@ Install the Intel(R) SGX PSW
 ----------------------------
 ### Prerequisites
 - Ensure that you have one of the following operating systems:  
-  * Ubuntu\* 16.04.3 LTS Desktop 64bits
-  * Ubuntu\* 16.04.3 LTS Server 64bits
+  * Ubuntu\* 16.04 LTS Desktop 64bits
+  * Ubuntu\* 16.04 LTS Server 64bits
   * Red Hat Enterprise Linux Server release 7.4 64bits
   * CentOS 7.4.1708 64bits
   * Fedora 27 Server 64bits
-  * Fedora 27 Workstation 64bits
   * SUSE Linux Enterprise Server 12 64bits
 - Ensure that you have a system with the following required hardware:  
   * 6th Generation Intel(R) Core(TM) Processor or newer


### PR DESCRIPTION
Fedora 27 workstation is not officially validated.
Remove the minor version of ubuntu version.
Signed-off-by: Yu Yuan <yuan.yu@intel.com>