### PR TITLE
install sim lib by default

### DIFF
--- a/linux/installer/common/sdk/Makefile
+++ b/linux/installer/common/sdk/Makefile
@@ -61,10 +61,10 @@ ifeq ($(INSTALLER_FORM),BIN)
 else
 	@sed -i "s#\(libdir=\).*#\1/usr/lib#" $(SOURCE_INSTALL_PATH)/pkgconfig/libsgx_uae_service_sim.pc
 	@sed -i "s#\(libdir=\).*#\1/usr/lib#" $(SOURCE_INSTALL_PATH)/pkgconfig/libsgx_urts_sim.pc
-	mv $(SDK_LIB_PATH)/libsgx_uae_service_sim.so $(DESTDIR)/usr/lib
-	mv $(SDK_LIB_PATH)/libsgx_urts_sim.so $(DESTDIR)/usr/lib
 	mv $(SOURCE_INSTALL_PATH)/pkgconfig/libsgx_uae_service_sim.pc $(DESTDIR)/usr/lib/pkgconfig
 	mv $(SOURCE_INSTALL_PATH)/pkgconfig/libsgx_urts_sim.pc $(DESTDIR)/usr/lib/pkgconfig
 	mv $(SOURCE_INSTALL_PATH)/pkgconfig/libsgx_uae_service.pc $(DESTDIR)/usr/lib/pkgconfig
 	mv $(SOURCE_INSTALL_PATH)/pkgconfig/libsgx_urts.pc $(DESTDIR)/usr/lib/pkgconfig
 endif
+	mv $(SDK_LIB_PATH)/libsgx_uae_service_sim.so $(DESTDIR)/usr/lib
+	mv $(SDK_LIB_PATH)/libsgx_urts_sim.so $(DESTDIR)/usr/lib


### PR DESCRIPTION
Fix the ldd issues when app built in sim mode:

daveti@sgx-59:~/git/linux-sgx/SampleCode/SampleEnclave2$ ldd ./app
linux-vdso.so.1 =>  (0x00007ffd317f5000)
**libsgx_urts_sim.so => not found**
libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f25a1124000)
libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f25a0da2000)
libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f25a0b8c000)
libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f25a07c2000)
/lib64/ld-linux-x86-64.so.2 (0x00007f25a1341000)
libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f25a04b9000)
