### PR TITLE
libsample_libcrypto.so: Fix link error

### DIFF
--- a/sdk/sample_libcrypto/Makefile
+++ b/sdk/sample_libcrypto/Makefile
@@ -60,7 +60,7 @@ all: $(LIBSAMPLECRYPTO) | $(BUILD_DIR)
 	@$(CP) $< $|
 
 $(LIBSAMPLECRYPTO): $(OBJS) $(C_OBJS)
-	$(CXX) $(CXXFLAGS) -shared -Wl,-soname,$(LIBSAMPLECRYPTO) $< -o $@ $(LDFLAGS)	
+	$(CXX) $(CXXFLAGS) -shared -Wl,-soname,$(LIBSAMPLECRYPTO) $^ -o $@ $(LDFLAGS)	
 
 $(C_OBJS): %.o: $(IPPDISP_DIR)/%.c
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
The C_OBJS is forgotten to link OBJS togeter in Makefile.
This mistake causes a build failure on SampleCode/RemoteAttestation:

/opt/intel/sgxsdk/SampleCode/RemoteAttestation/sample_libcrypto/libsample_libcrypto.so:
undefined reference to `sgx_disp_ippsAES_GCMGetTag'
/opt/intel/sgxsdk/SampleCode/RemoteAttestation/sample_libcrypto/libsample_libcrypto.so:
undefined reference to `sgx_disp_ippsAES_GCMGetSize'
...

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>