### PR TITLE
Minor fixes for compilation errors

### DIFF
--- a/sdk/sign_tool/SignTool/elf_helper.h
+++ b/sdk/sign_tool/SignTool/elf_helper.h
@@ -44,7 +44,7 @@ static void dump_textrel(const uint64_t& offset)
     using namespace std;
 
     cerr << "warning: TEXTRELs found at offset: "
-         << hex << showbase     /* show the '0x' prefix */
+         << std::hex << showbase     /* show the '0x' prefix */
          << offset << endl;
 }
 

--- a/sdk/sign_tool/SignTool/manage_metadata.cpp
+++ b/sdk/sign_tool/SignTool/manage_metadata.cpp
@@ -229,7 +229,7 @@ bool CMetadata::get_time(uint32_t *date)
     uint32_t tmp_date = (timeinfo->tm_year+1900)*10000 + (timeinfo->tm_mon+1)*100 + timeinfo->tm_mday;
     stringstream ss;
     ss<<"0x"<<tmp_date;
-    ss>>hex>>tmp_date;
+    ss>>std::hex>>tmp_date;
     *date = tmp_date;
     return true;
 }

--- a/sdk/simulation/uae_service_sim/linux/platform_service_sim.cpp
+++ b/sdk/simulation/uae_service_sim/linux/platform_service_sim.cpp
@@ -37,7 +37,9 @@
 #include <sys/types.h>
 #include <stdlib.h>
 #include <pwd.h>
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 
 static Mutex g_pse_sim_lock;

--- a/sdk/tlibc/gen/spinlock.c
+++ b/sdk/tlibc/gen/spinlock.c
@@ -34,7 +34,7 @@
 static inline void _mm_pause(void) __attribute__((always_inline));
 static inline int _InterlockedExchange(int volatile * dst, int val) __attribute__((always_inline));
 
-static inline void _mm_pause(void)
+static inline void _mm_pause(void)  /* definition requires -ffreestanding */
 {
     __asm __volatile(
         "pause"


### PR DESCRIPTION
Replace the definition of _mm_pause with just an include of
xmmintrin.h.
Guard the definition of __STDC_FORMAT_MACROS with #ifndef/#endif.

GCC errors on the _mm_pause definition and claims that we are redefining a builtin, so just include the header for the builtin.
The #define in the simulation file was considered redefined in our toolchain, so this just adds a simple guard to avoid redefinition.