### PR TITLE
Emitter Plugin for Edger8r.

### DIFF
--- a/sdk/edger8r/linux/Ast.ml
+++ b/sdk/edger8r/linux/Ast.ml
@@ -191,6 +191,26 @@ type enclave = {
   eexpr : expr list;        (* expressions inside enclave. *)
 }
 
+(*
+  Plugin.ml operates on an enclave_content instance.
+  CodeGen.ml calls Plugin.ml if a plugin is installed and hence
+  depends on Plugin.ml.
+  To prevent cyclic dependency between Plugin.ml and Codegen.ml,
+  enclave_content is defined here. Additionally, the enclave_content 
+  type in CodeGen.ml is defined to be equivalent to the enclave_content 
+  type defined here.
+*)
+type enclave_content = {
+  file_shortnm : string; (* the short name of original EDL file *)
+  enclave_name : string; (* the normalized C identifier *)
+
+  include_list : string list;
+  import_exprs : import_decl list;
+  comp_defs    : composite_type list;
+  tfunc_decls  : trusted_func   list;
+  ufunc_decls  : untrusted_func list;
+}
+
 (* -------------------------------------------------------------------
  *  Some utility function to manupulate types defined in AST.
  * -------------------------------------------------------------------

--- a/sdk/edger8r/linux/CodeGen.ml
+++ b/sdk/edger8r/linux/CodeGen.ml
@@ -39,7 +39,7 @@ open Util                               (* for failwithf *)
  *)
 
 (* This record type is used to better organize a value of Ast.enclave *)
-type enclave_content = {
+type enclave_content = Ast.enclave_content = {
   file_shortnm : string; (* the short name of original EDL file *)
   enclave_name : string; (* the normalized C identifier *)
 
@@ -1714,5 +1714,9 @@ let gen_enclave_code (e: Ast.enclave) (ep: edger8r_params) =
     check_duplication ec;
     check_allow_list ec;
     (if not ep.header_only then check_priv_funcs ec);
-    (if ep.gen_untrusted then (gen_untrusted_header ec; if not ep.header_only then gen_untrusted_source ec));
-    (if ep.gen_trusted then (gen_trusted_header ec; if not ep.header_only then gen_trusted_source ec))
+    if Plugin.available() then
+      Plugin.gen_edge_routines ec ep
+    else (
+      (if ep.gen_untrusted then (gen_untrusted_header ec; if not ep.header_only then gen_untrusted_source ec));
+      (if ep.gen_trusted then (gen_trusted_header ec; if not ep.header_only then gen_trusted_source ec))
+    )

--- a/sdk/edger8r/linux/Plugin.ml
+++ b/sdk/edger8r/linux/Plugin.ml
@@ -1,0 +1,22 @@
+(* 
+    Dependency injection plugin to allow custom code generation
+    from EDL. CodeGen.ml calls into Plugin.available to check 
+    if a plugin available. If a plugin is available, then it calls 
+    Plugin.gen_edge_routines to generate custom code. 
+    Otherwise, it generates code for Intel(R) SGX  SDK.
+*)
+
+type plugin = {
+    mutable available: bool;
+    mutable gen_edge_routines:
+         Ast.enclave_content -> Util.edger8r_params -> unit;
+}
+
+(* Instance fields will be populated by Open Enclave *)
+let instance = {
+    available = false;
+    gen_edge_routines = fun ec ep -> Printf.printf "Plugin not loaded.\n"
+}
+
+let available () = instance.available
+let gen_edge_routines ec ep = instance.gen_edge_routines ec ep


### PR DESCRIPTION
This changelist allows support for emitter plugins.
Plugin.ml defines the plugin interface:
   1. available: bool 
      Is true if a plugin is available.
   2. gen_edge_routines:  Ast.enclave_content -> Util.edger8r_params -> unit
      Generate edge routines given the processed enclave content and command line parameters.

CodeGen.ml checks whether a plugin is available and if so, invokes the plugin to emit edge routines.
Currently, plugins are expected to be compiled into the edger8r binary.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>