### PR TITLE
Localize -O0 to necessary functions

### DIFF
--- a/sdk/simulation/assembly/lowlib.h
+++ b/sdk/simulation/assembly/lowlib.h
@@ -40,6 +40,15 @@
 
 #include <stdint.h>
 
+#if defined(__GNUC__) && !defined(__clang__)
+#define LOAD_REGS_ATTRIBUTES \
+  __attribute__((optimize("-O0,-fno-omit-frame-pointer")))
+#elif defined(__clang__)
+#define LOAD_REGS_ATTRIBUTES [[clang::optnone]]
+#else
+#pragma warning "Unsupported compiler for per-function deoptimization"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sdk/simulation/tinst/Makefile
+++ b/sdk/simulation/tinst/Makefile
@@ -55,10 +55,6 @@ all: $(LIBSESIMU_T)
 $(LIBSESIMU_T): $(OBJS)
 	$(AR) rcs $@ $^
 
-# Explicitly disable optimization for 't_instructions.cpp',
-# since the '_SE3' function has assumptions on stack layout.
-t_instructions.o: CXXFLAGS += -O0
-
 .PHONY: clean
 clean:
 	@$(RM) $(OBJS) $(LIBSESIMU_T)

--- a/sdk/simulation/tinst/t_instructions.cpp
+++ b/sdk/simulation/tinst/t_instructions.cpp
@@ -286,6 +286,8 @@ static void _EREPORT(const sgx_target_info_t* ti, const sgx_report_data_t* rd, s
 static void
 _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xdi) __attribute__((section(".nipx")));
 
+// The call to load_regs assumes the existence of a frame pointer.
+LOAD_REGS_ATTRIBUTES
 static void
 _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xdi)
 {
@@ -323,9 +325,6 @@ _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xd
 
 // Master entry functions
 
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-
 uintptr_t _SE3(uintptr_t xax, uintptr_t xbx, uintptr_t xcx,
                uintptr_t xdx, uintptr_t xsi, uintptr_t xdi)
 {
@@ -350,5 +349,3 @@ uintptr_t _SE3(uintptr_t xax, uintptr_t xbx, uintptr_t xcx,
     GP();
     return (uintptr_t)-1;
 }
-
-#pragma GCC pop_options

--- a/sdk/simulation/uinst/Makefile
+++ b/sdk/simulation/uinst/Makefile
@@ -63,7 +63,7 @@ enclave_mngr.o: enclave_mngr.cpp
 # since the '_SE3' function has assumptions on stack layout.
 #
 u_instructions.o: u_instructions.cpp
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -O0 -Wno-error=cpp -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -Wno-error=cpp -c $< -o $@
 
 $(LIBSESIMU_U): u_instructions.o enclave_mngr.o $(OBJ1)
 	$(AR) rcs $@ $^

--- a/sdk/simulation/uinst/u_instructions.cpp
+++ b/sdk/simulation/uinst/u_instructions.cpp
@@ -208,7 +208,8 @@ uintptr_t _EREMOVE(const void *epc_lin_addr)
 
 // Master entry functions
 
-
+// The call to load_regs assumes the existence of a frame pointer.
+LOAD_REGS_ATTRIBUTES
 void _SE3(uintptr_t xax, uintptr_t xbx,
           uintptr_t xcx, uintptr_t xdx,
           uintptr_t xsi, uintptr_t xdi)


### PR DESCRIPTION
The load_regs assembly function uses its caller's frame pointer.
C/C++ compilers are allowed to make optimizations to their
representation of the stack, and frequently omit the frame pointer.

The functions _EEXIT in t_instructions.cpp and _SE3 in
u_instructions.cpp both call load_regs, and thus should be the only ones
that should be affected by deoptimization.

Even -O0 may omit the frame pointer (indeed we found this to be the case
when compiling with GCC 7.3.0), so this change also makes that requirement
explicit by by means of -fno-omit-frame-pointer.

An added bonus of switching the -O0 flag over to an attribute in source
code is that alternate build tools are easier to port to :)

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>