### PR TITLE
seed with nanosecond timestamp in simulation mode

### DIFF
--- a/sdk/simulation/urtssim/enclave_creator_sim.cpp
+++ b/sdk/simulation/urtssim/enclave_creator_sim.cpp
@@ -229,7 +229,9 @@ int EnclaveCreatorSim::initialize(sgx_enclave_id_t enclave_id)
     assert(global_data_sim_ptr != NULL);
 
     // Initialize the `seed' to `g_global_data_sim'.
-    global_data_sim_ptr->seed = (uint64_t)time(NULL);
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    global_data_sim_ptr->seed = (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
 
     global_data_sim_ptr->secs_ptr = ce->get_secs();
     sgx_cpu_svn_t temp_cpusvn = {{0}};


### PR DESCRIPTION
This pull request is trying to solve the issue #246.

ChangeLog v1->v2:
- remove inclusion of <time.h> (per @sergefdrv)

ChangeLog [v2](https://github.com/intel/linux-sgx/compare/master...Naoya-Horiguchi:post/nanosecond_seeding.v2)->v3:
- use `clock_gettime()` instead of `high_resolution_clock`

--- quoting patch description below ---
Currently we seed random number generator with timestamp in seconds.
Because of this we have to insert 1 second delay in each testcase to
ensure the randomness, which prevents us from testing applications
effeciently.

Simulation mode is not supposed to be used in production, but
developing applications on environtment without SGX HW is still common.
So let's seed with timestamp in nanoseconds in simulation mode.

Signed-off-by: Naoya Horiguchi <n-horiguchi@ah.jp.nec.com>