### PR TITLE
Remove an unused #include

### DIFF
--- a/sdk/gperftools/gperftools-2.5/src/base/vdso_support.cc
+++ b/sdk/gperftools/gperftools-2.5/src/base/vdso_support.cc
@@ -43,7 +43,6 @@
 #include <stddef.h>   // for ptrdiff_t
 
 #include "base/atomicops.h"  // for MemoryBarrier
-#include "base/linux_syscall_support.h"
 #include "base/logging.h"
 #include "base/dynamic_annotations.h"
 #include "base/basictypes.h"  // for COMPILE_ASSERT


### PR DESCRIPTION
This was committed upstream at https://github.com/gperftools/gperftools/commit/977e0d45003514d088e4bb83474c985094acee47