### PR TITLE
Remove #include sgx_urts.h from sgx_uswitchless

### DIFF
--- a/common/inc/sgx_uswitchless.h
+++ b/common/inc/sgx_uswitchless.h
@@ -72,7 +72,6 @@
 #include "sgx_error.h"
 #include "sgx_eid.h"
 #include "sgx_defs.h"
-#include "sgx_urts.h"
 
 /*
  * A worker can be either trusted (executed inside enclave) or untrusted


### PR DESCRIPTION
The sgx_uswitchless.h header is used in both trusted and untrusted
contexts from transitive inclusions. The sgx_urts.h header is strictly
an untrusted domain header. Users that depend on the untrusted runtime
should not depend on the transitive include behavior to provide
sgx_urts.h.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>