### PR TITLE
Fix buffer check error of p_additional_MACtext_length

### DIFF
--- a/sdk/tseal/tSeal.cpp
+++ b/sdk/tseal/tSeal.cpp
@@ -202,7 +202,7 @@ extern "C" sgx_status_t sgx_unseal_data(const sgx_sealed_data_t *p_sealed_data, 
     {
         return SGX_ERROR_INVALID_PARAMETER;
     }
-    if (!sgx_is_within_enclave(p_decrypted_text_length, sizeof(p_decrypted_text_length)))
+    if (!sgx_is_within_enclave(p_decrypted_text_length, sizeof(*p_decrypted_text_length)))
     {
         return SGX_ERROR_INVALID_PARAMETER;
     }

--- a/sdk/tseal/tSeal.cpp
+++ b/sdk/tseal/tSeal.cpp
@@ -217,8 +217,8 @@ extern "C" sgx_status_t sgx_unseal_data(const sgx_sealed_data_t *p_sealed_data, 
     }
 
     if((p_additional_MACtext_length != NULL) && 
-       (!(sgx_is_within_enclave(p_additional_MACtext_length, sizeof(p_additional_MACtext_length)) ||
-          sgx_is_outside_enclave(p_additional_MACtext_length, sizeof(p_additional_MACtext_length)))))
+       (!(sgx_is_within_enclave(p_additional_MACtext_length, sizeof(*p_additional_MACtext_length)) ||
+          sgx_is_outside_enclave(p_additional_MACtext_length, sizeof(*p_additional_MACtext_length)))))
     {
         return SGX_ERROR_INVALID_PARAMETER;
     }

--- a/sdk/tseal/tSeal_aad.cpp
+++ b/sdk/tseal/tSeal_aad.cpp
@@ -196,8 +196,8 @@ extern "C" sgx_status_t sgx_unmac_aadata(const sgx_sealed_data_t *p_sealed_data,
     {
         return SGX_ERROR_INVALID_PARAMETER;
     }
-    if(!(sgx_is_within_enclave(p_additional_MACtext_length, sizeof(p_additional_MACtext_length)) ||
-        sgx_is_outside_enclave(p_additional_MACtext_length, sizeof(p_additional_MACtext_length))))
+    if(!(sgx_is_within_enclave(p_additional_MACtext_length, sizeof(*p_additional_MACtext_length)) ||
+        sgx_is_outside_enclave(p_additional_MACtext_length, sizeof(*p_additional_MACtext_length))))
     {
         return SGX_ERROR_INVALID_PARAMETER;
     }


### PR DESCRIPTION
As claimed in the developer's reference, `sgx_unmac_aadata` and `sgx_unseal_data` accept an argument `p_additional_MACtext_length` which is a `uint32_t *` and points to the length of the additional mac text length (`uint32_t`). These two functions check if the length arg is within the enclave memory area, which is essential. However, the check codes invoking `sgx_is_within_enclave` and `sgx_is_outside_enclave` set the length of buffer to 8 which is `sizeof(uint32_t *)` instead of 4 which is `sizeof(uint32_t)`. Obviously, it is a logic error. It should only check 4 bytes instead of 8. Patch and immediate upgrade are desired.

Signed-off-by: Yu Ding <dingelish@gmail.com>