### PR TITLE
Allow enclaves to be created from buffers

### DIFF
--- a/common/inc/sgx_urts.h
+++ b/common/inc/sgx_urts.h
@@ -34,6 +34,8 @@
 #ifndef _SGX_URTS_H_
 #define _SGX_URTS_H_
 
+#include <stddef.h>
+
 #include "sgx_attributes.h"
 #include "sgx_error.h"
 #include "sgx_eid.h"
@@ -66,23 +68,44 @@ typedef uint8_t sgx_launch_token_t[1024];
 #define SGX_DEBUG_FLAG ((int)0)
 #endif
 
-sgx_status_t SGXAPI sgx_create_enclave(const char *file_name, 
-                                       const int debug, 
-                                       sgx_launch_token_t *launch_token, 
-                                       int *launch_token_updated, 
-                                       sgx_enclave_id_t *enclave_id, 
+sgx_status_t SGXAPI sgx_create_enclave(const char *file_name,
+                                       const int debug,
+                                       sgx_launch_token_t *launch_token,
+                                       int *launch_token_updated,
+                                       sgx_enclave_id_t *enclave_id,
                                        sgx_misc_attribute_t *misc_attr);
 
 
+sgx_status_t SGXAPI sgx_create_enclave_from_buffer(
+                        uint8_t *buffer,
+                        size_t buffer_size,
+                        const int debug,
+                        sgx_launch_token_t *launch_token,
+                        int *launch_token_updated,
+                        sgx_enclave_id_t *enclave_id,
+                        sgx_misc_attribute_t *misc_attr);
 
-sgx_status_t SGXAPI sgx_create_enclave_ex(const char * file_name, 
-                                          const int debug, 
-                                          sgx_launch_token_t * launch_token, 
-                                          int * launch_token_updated, 
-                                          sgx_enclave_id_t * enclave_id, 
-                                          sgx_misc_attribute_t * misc_attr,  
-                                          const uint32_t ex_features, 
+
+sgx_status_t SGXAPI sgx_create_enclave_ex(const char * file_name,
+                                          const int debug,
+                                          sgx_launch_token_t * launch_token,
+                                          int * launch_token_updated,
+                                          sgx_enclave_id_t * enclave_id,
+                                          sgx_misc_attribute_t * misc_attr,
+                                          const uint32_t ex_features,
                                           const void* ex_features_p[32]);
+
+
+sgx_status_t SGXAPI sgx_create_enclave_from_buffer_ex(
+                        uint8_t *buffer,
+                        size_t buffer_size,
+                        const int debug,
+                        sgx_launch_token_t * launch_token,
+                        int * launch_token_updated,
+                        sgx_enclave_id_t * enclave_id,
+                        sgx_misc_attribute_t * misc_attr,
+                        const uint32_t ex_features,
+                        const void* ex_features_p[32]);
 
 
 sgx_status_t SGXAPI sgx_create_encrypted_enclave(
@@ -93,6 +116,18 @@ sgx_status_t SGXAPI sgx_create_encrypted_enclave(
                         sgx_enclave_id_t *enclave_id,
                         sgx_misc_attribute_t *misc_attr,
                         uint8_t* sealed_key);
+
+
+sgx_status_t SGXAPI sgx_create_encrypted_enclave_from_buffer(
+                        uint8_t *buffer,
+                        size_t buffer_size,
+                        const int debug,
+                        sgx_launch_token_t *launch_token,
+                        int *launch_token_updated,
+                        sgx_enclave_id_t *enclave_id,
+                        sgx_misc_attribute_t *misc_attr,
+                        uint8_t* sealed_key);
+
 
 sgx_status_t SGXAPI sgx_destroy_enclave(const sgx_enclave_id_t enclave_id);
 

--- a/psw/urts/enclave.cpp
+++ b/psw/urts/enclave.cpp
@@ -112,19 +112,21 @@ on_exit:
 
 sgx_status_t CEnclave::initialize(const se_file_t& file, const sgx_enclave_id_t enclave_id, void * const start_addr, const uint64_t enclave_size, const uint32_t tcs_policy, const uint32_t enclave_version, const uint32_t tcs_min_pool)
 {
-    uint32_t name_len = file.name_len;
-    if (file.unicode)
-        name_len *= (uint32_t)sizeof(wchar_t);
+    if (file.name != NULL) {
+        uint32_t name_len = file.name_len;
+        if (file.unicode)
+            name_len *= (uint32_t)sizeof(wchar_t);
 
-    const int buf_len = name_len + 4; //+4, because we need copy the charactor of string end ('\0').;
+        const int buf_len = name_len + 4; //+4, because we need copy the charactor of string end ('\0').;
 
-    m_enclave_info.lpFileName = calloc(1, buf_len);
-    if (m_enclave_info.lpFileName == NULL)
-        return SGX_ERROR_OUT_OF_MEMORY;
+        m_enclave_info.lpFileName = calloc(1, buf_len);
+        if (m_enclave_info.lpFileName == NULL)
+            return SGX_ERROR_OUT_OF_MEMORY;
 
-    memcpy_s(m_enclave_info.lpFileName, name_len, file.name, name_len);
-    m_enclave_info.unicode = file.unicode?0:1;
-    m_enclave_info.file_name_size = name_len;
+        memcpy_s(m_enclave_info.lpFileName, name_len, file.name, name_len);
+        m_enclave_info.unicode = file.unicode?0:1;
+        m_enclave_info.file_name_size = name_len;
+    }
 
     m_enclave_info.struct_version = DEBUG_INFO_STRUCT_VERSION;
 


### PR DESCRIPTION
To that end, also allow the m_enclave_info.lpFileName field of a loaded CEnclave to be empty, since an enclave can no longer be tied directly to a file.

Signed-off-by: Conrad Parker <conradparker@google.com>