### PR TITLE
Remove using namespace std

### DIFF
--- a/common/src/sgx_profile.cpp
+++ b/common/src/sgx_profile.cpp
@@ -38,7 +38,6 @@
 #include "sgx_profile.h"
 #include "se_time.h"
 #include <string.h>
-using namespace std;
 
 typedef struct _profile_item_t{
     const char *str;  /* tag */
@@ -46,7 +45,7 @@ typedef struct _profile_item_t{
     long long time;   /* current time */
 } profile_item_t;
 
-static vector<profile_item_t> profile_items;
+static std::vector<profile_item_t> profile_items;
 static int alloc_size;
 static int used_size;
 const int MALLOC_SIZE = 1000;
@@ -108,7 +107,7 @@ extern "C" void profile_output(const char* filename)
 {
     int i,j;
 
-    ofstream fs;
+    std::ofstream fs;
     fs.open(filename); /* do not overwritten previous value */
 
     fs << "freq: " << freq <<endl;

--- a/psw/ae/aesm_service/source/aesm_wrapper/inc/CAESMServer.h
+++ b/psw/ae/aesm_service/source/aesm_wrapper/inc/CAESMServer.h
@@ -39,8 +39,6 @@
 #include "AESMQueueManager.h"
 #include <stdexcept>
 
-using namespace std;
-
 /*
  * Encapsulates all AESM server logic
  */

--- a/psw/ae/aesm_service/source/oal/internal_log.cpp
+++ b/psw/ae/aesm_service/source/oal/internal_log.cpp
@@ -59,7 +59,6 @@ static ae_error_t init_log_file(void)
 }
 
 #include <string>
-using namespace std;
 
 static const char *get_sgx_status_t_string(sgx_status_t status);
 static const char *get_ae_error_t_string(ae_error_t ae_error);

--- a/psw/ae/aesm_service/source/upse/interface_psda.cpp
+++ b/psw/ae/aesm_service/source/upse/interface_psda.cpp
@@ -44,9 +44,6 @@
 #define BREAK_IF_TRUE(x, Sts, ErrCode)  if (x)    { Sts = ErrCode; break; }
 #define BREAK_IF_FALSE(x, Sts, ErrCode) if (!(x)) { Sts = ErrCode; break; }
 
-using namespace std;
-
-
 static JVM_COMM_BUFFER commBuf_s1, commBuf_s3;
 static INT32 responseCode;
 

--- a/psw/urts/enclave.cpp
+++ b/psw/urts/enclave.cpp
@@ -45,8 +45,6 @@
 #include "rts.h"
 
 
-using namespace std;
-
 int do_ecall(const int fn, const void *ocall_table, const void *ms, CTrustThread *trust_thread);
 int do_ocall(const bridge_fn_t bridge, void *ms);
 

--- a/psw/urts/linux/misc.cpp
+++ b/psw/urts/linux/misc.cpp
@@ -34,10 +34,8 @@
 #include <dirent.h>
 #include <vector>
 
-using namespace std;
-
 //get all thread id of current process.
-void get_thread_set(vector<se_thread_id_t> &thread_vector)
+void get_thread_set(std::vector<se_thread_id_t> &thread_vector)
 {
     DIR*   dir = NULL;
     struct dirent* dirent = NULL;

--- a/psw/urts/loader.cpp
+++ b/psw/urts/loader.cpp
@@ -103,7 +103,7 @@ void* CLoader::get_symbol_address(const char * const symbol)
 }
 
 // is_relocation_page returns true if the specified RVA is a writable relocation page based on the bitmap.
-bool CLoader::is_relocation_page(const uint64_t rva, vector<uint8_t> *bitmap)
+bool CLoader::is_relocation_page(const uint64_t rva, std::vector<uint8_t> *bitmap)
 {
     uint64_t page_frame = rva >> SE_PAGE_SHIFT;
     //NOTE:
@@ -181,7 +181,7 @@ int CLoader::build_mem_region(const section_info_t &sec_info)
     return SGX_SUCCESS;
 }
 
-int CLoader::build_sections(vector<uint8_t> *bitmap)
+int CLoader::build_sections(std::vector<uint8_t> *bitmap)
 {
     int ret = SGX_SUCCESS;
     std::vector<Section*> sections = m_parser.get_sections();
@@ -372,7 +372,7 @@ int CLoader::build_context(const uint64_t start_rva, layout_entry_t *layout)
                 ptcs->ogs_base += rva;
                 if(!(attributes & PAGE_ATTR_EREMOVE))
                 {
-                    m_tcs_list.push_back(make_pair(GET_PTR(tcs_t, m_start_addr, rva), false));
+                  m_tcs_list.push_back(std::make_pair(GET_PTR(tcs_t, m_start_addr, rva), false));
                 }
                 sinfo.flags = layout->si_flags;
                 if(SGX_SUCCESS != (ret = build_pages(rva, ((uint64_t)layout->page_count) << SE_PAGE_SHIFT, added_page, sinfo, attributes)))
@@ -417,7 +417,7 @@ int CLoader::build_context(const uint64_t start_rva, layout_entry_t *layout)
 #ifndef SE_SIM
         if(layout->id == LAYOUT_ID_TCS_DYN)
         {
-            m_tcs_list.push_back(make_pair(GET_PTR(tcs_t, m_start_addr, rva), true));
+          m_tcs_list.push_back(std::make_pair(GET_PTR(tcs_t, m_start_addr, rva), true));
         }
 #endif
     }
@@ -486,7 +486,7 @@ int CLoader::build_image(SGXLaunchToken * const lc, sgx_attributes_t * const sec
     // If load_enclave_ex try to load the enclave for the 2nd time,
     // the enclave image is already patched, and parser cannot read the information.
     // For linux, there's no map conflict. We assume load_enclave_ex will not do the retry.
-    vector<uint8_t> bitmap;
+    std::vector<uint8_t> bitmap;
     if(!m_parser.get_reloc_bitmap(bitmap))
         return SGX_ERROR_INVALID_ENCLAVE;
 
@@ -564,12 +564,12 @@ int CLoader::validate_layout_table()
 {
     layout_t *layout_start = GET_PTR(layout_t, m_metadata, m_metadata->dirs[DIR_LAYOUT].offset);
     layout_t *layout_end = GET_PTR(layout_t, m_metadata, m_metadata->dirs[DIR_LAYOUT].offset + m_metadata->dirs[DIR_LAYOUT].size);
-    vector<pair<uint64_t, uint64_t>> rva_vector;
+    std::vector<std::pair<uint64_t, uint64_t>> rva_vector;
     for (layout_t *layout = layout_start; layout < layout_end; layout++)
     {
         if(!IS_GROUP_ID(layout->entry.id))  // layout entry
         {
-            rva_vector.push_back(make_pair(layout->entry.rva, ((uint64_t)layout->entry.page_count) << SE_PAGE_SHIFT));
+          rva_vector.push_back(std::make_pair(layout->entry.rva, ((uint64_t)layout->entry.page_count) << SE_PAGE_SHIFT));
             if(layout->entry.content_offset)
             {
                 if(false == is_metadata_buffer(layout->entry.content_offset, layout->entry.content_size))
@@ -598,7 +598,7 @@ int CLoader::validate_layout_table()
                     {
                         return SGX_ERROR_INVALID_METADATA;
                     }
-                    rva_vector.push_back(make_pair(entry->rva + load_step, ((uint64_t)entry->page_count) << SE_PAGE_SHIFT));
+                    rva_vector.push_back(std::make_pair(entry->rva + load_step, ((uint64_t)entry->page_count) << SE_PAGE_SHIFT));
                     // no need to check integer overflow for entry->rva + load_step, because
                     // entry->rva and load_step are less than enclave_size, whose size is no more than 37 bit
                 }
@@ -606,7 +606,7 @@ int CLoader::validate_layout_table()
         }
     }
     sort(rva_vector.begin(), rva_vector.end());
-    for (vector<pair<uint64_t, uint64_t>>::iterator it = rva_vector.begin(); it != rva_vector.end(); it++)
+    for (std::vector<std::pair<uint64_t, uint64_t>>::iterator it = rva_vector.begin(); it != rva_vector.end(); it++)
     {
         if(!IS_PAGE_ALIGNED(it->first))
         {

--- a/psw/urts/loader.h
+++ b/psw/urts/loader.h
@@ -77,7 +77,7 @@ private:
     int build_contexts(layout_t *layout_start, layout_t *layout_end, uint64_t delta);
     int build_partial_page(const uint64_t rva, const uint64_t size, const void *source, const sec_info_t &sinfo, const uint32_t attr);
     int build_pages(const uint64_t start_rva, const uint64_t size, const void *source, const sec_info_t &sinfo, const uint32_t attr);
-    bool is_relocation_page(const uint64_t rva, vector<uint8_t> *bitmap);
+  bool is_relocation_page(const uint64_t rva, std::vector<uint8_t> *bitmap);
 
     bool is_ae(const enclave_css_t *enclave_css);
     bool is_metadata_buffer(uint32_t offset, uint32_t size);
@@ -86,7 +86,7 @@ private:
     int validate_patch_table();
     int validate_metadata();
     int get_debug_flag(const token_t * const launch);
-    virtual int build_sections(vector<uint8_t> *bitmap);
+  virtual int build_sections(std::vector<uint8_t> *bitmap);
     int set_context_protection(layout_t *layout_start, layout_t *layout_end, uint64_t delta);
 
     uint8_t             *m_mapped_file_base;

--- a/psw/urts/parser/binparser.h
+++ b/psw/urts/parser/binparser.h
@@ -41,8 +41,6 @@
 #include <stdint.h>
 #include <vector>
 #include <string>
-using std::vector;
-using std::string;
 
 #define ENCLAVE_MAX_SIZE_32 0xffffffff
 #define ENCLAVE_MAX_SIZE_64 0x1fffffffff
@@ -77,17 +75,17 @@ public:
     virtual const uint8_t* get_start_addr() const = 0;
 
     // Get a vector of sections to be loaded
-    virtual const vector<Section *>& get_sections() const = 0;
+    virtual const std::vector<Section *>& get_sections() const = 0;
 
     // Get the TLS section
     virtual const Section* get_tls_section() const = 0;
 
     virtual uint64_t get_symbol_rva(const char* name) const = 0;
 
-    virtual bool get_reloc_bitmap(vector<uint8_t> &bitmap) = 0;
+    virtual bool get_reloc_bitmap(std::vector<uint8_t> &bitmap) = 0;
 
     virtual void get_reloc_entry_offset(const char* sec_name,
-                                        vector<uint64_t>& offsets) = 0;
+                                        std::vector<uint64_t>& offsets) = 0;
 
     // !We need to put this method into BinParser class since
     // !the `global_data_t' is platform-dependent as the parser.
@@ -107,7 +105,7 @@ public:
 
     virtual sgx_status_t get_info(enclave_diff_info_t *enclave_diff_info) = 0;
 
-    virtual void get_executable_sections(vector<const char *>& xsec_names) const = 0;
+    virtual void get_executable_sections(std::vector<const char *>& xsec_names) const = 0;
     virtual bool set_memory_protection(uint64_t enclave_base_addr, bool is_after_initialization) = 0;
     virtual void get_pages_to_protect(uint64_t, std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>&) const = 0;
     virtual bool has_init_section() const = 0;

--- a/psw/urts/parser/elfparser.cpp
+++ b/psw/urts/parser/elfparser.cpp
@@ -184,7 +184,7 @@ bool parse_dyn(const ElfW(Ehdr) *elf_hdr, ElfW(Dyn)* dyn_info)
  * We only need to search `.dynsym' for undefined symbols.
  */
 bool check_symbol_table(const ElfW(Ehdr) *elf_hdr, const ElfW(Dyn) *dyn_info,
-                        map<string, uint64_t>& sym_table)
+                        std::map<std::string, uint64_t>& sym_table)
 {
     const ElfW(Shdr) *sh_symtab = get_section_by_addr(elf_hdr, dyn_info[DT_SYMTAB].d_un.d_ptr);
 
@@ -245,7 +245,7 @@ bool check_symbol_table(const ElfW(Ehdr) *elf_hdr, const ElfW(Dyn) *dyn_info,
     // If the enclave if compiled/linked with -fpie/-pie, and setting the
     // enclave entry to `enclave_entry', the `st_name' for `enclave_entry'
     // will be 0 in `.dynsym'.
-    map<string, uint64_t>::const_iterator it = sym_table.find("enclave_entry");
+    std::map<std::string, uint64_t>::const_iterator it = sym_table.find("enclave_entry");
     if (it == sym_table.end())
     {
         sym_table["enclave_entry"] = (uint64_t)elf_hdr->e_entry;
@@ -504,7 +504,7 @@ Section* build_section(const uint8_t* raw_data, uint64_t size, uint64_t virtual_
 }
 
 bool build_regular_sections(const uint8_t* start_addr,
-                            vector<Section *>& sections,
+                            std::vector<Section *>& sections,
                             const Section*& tls_sec,
                             uint64_t& metadata_offset,
                             uint64_t& metadata_block_size)
@@ -565,7 +565,7 @@ bool build_regular_sections(const uint8_t* start_addr,
     return true;
 }
 
-const Section* get_max_rva_section(const vector<Section*> sections)
+const Section* get_max_rva_section(const std::vector<Section*> sections)
 {
     size_t sec_size = sections.size();
 
@@ -672,7 +672,7 @@ const uint8_t* ElfParser::get_start_addr() const
     return m_start_addr;
 }
 
-const vector<Section *>& ElfParser::get_sections() const
+const std::vector<Section *>& ElfParser::get_sections() const
 {
     return m_sections;
 }
@@ -684,7 +684,7 @@ const Section* ElfParser::get_tls_section() const
 
 uint64_t ElfParser::get_symbol_rva(const char* name) const
 {
-    map<string, uint64_t>::const_iterator it = m_sym_table.find(name);
+    std::map<std::string, uint64_t>::const_iterator it = m_sym_table.find(name);
     if (it != m_sym_table.end())
         return it->second;
     else
@@ -700,7 +700,7 @@ bool ElfParser::has_text_reloc() const
     return false;
 }
 
-bool ElfParser::get_reloc_bitmap(vector<uint8_t>& bitmap)
+bool ElfParser::get_reloc_bitmap(std::vector<uint8_t>& bitmap)
 {
     // Clear the `bitmap' so that it is in a known state
     bitmap.clear();
@@ -781,7 +781,7 @@ bool ElfParser::get_reloc_bitmap(vector<uint8_t>& bitmap)
     return true;
 }
 
-void ElfParser::get_reloc_entry_offset(const char* sec_name, vector<uint64_t>& offsets)
+void ElfParser::get_reloc_entry_offset(const char* sec_name, std::vector<uint64_t>& offsets)
 {
     if (sec_name == NULL)
         return;
@@ -859,7 +859,7 @@ sgx_status_t ElfParser::get_info(enclave_diff_info_t *enclave_diff_info)
     return SGX_SUCCESS;
 }
 
-void ElfParser::get_executable_sections(vector<const char *>& xsec_names) const
+void ElfParser::get_executable_sections(std::vector<const char *>& xsec_names) const
 {
     xsec_names.clear();
 

--- a/psw/urts/parser/elfparser.h
+++ b/psw/urts/parser/elfparser.h
@@ -39,9 +39,6 @@
 #include <string>
 #include <map>
 
-using std::map;
-using std::string;
-
 class ElfParser : public BinParser, private Uncopyable {
 public:
     // The `start_addr' cannot be NULL
@@ -63,11 +60,11 @@ public:
 
     // The `section' here is a section in PE's concept.
     // It is in fact a `segment' in ELF's view.
-    const vector<Section *>& get_sections() const;
+    const std::vector<Section *>& get_sections() const;
     const Section* get_tls_section() const;
     uint64_t get_symbol_rva(const char* name) const;
 
-    bool get_reloc_bitmap(vector<uint8_t> &bitmap);
+    bool get_reloc_bitmap(std::vector<uint8_t> &bitmap);
     bool has_text_reloc() const;
     uint32_t get_global_data_size();
     bool update_global_data(const metadata_t *const metadata,
@@ -86,11 +83,11 @@ public:
     // To check whether current enclave has any TEXTREL:
     //   get_reloc_entry_offset(".text", offsets);
     void get_reloc_entry_offset(const char* sec_name,
-                                vector<uint64_t>& offsets);
+                                std::vector<uint64_t>& offsets);
 
     sgx_status_t modify_info(enclave_diff_info_t *enclave_diff_info);
     sgx_status_t get_info(enclave_diff_info_t *enclave_diff_info);
-    void get_executable_sections(vector<const char *>& xsec_names) const;
+    void get_executable_sections(std::vector<const char *>& xsec_names) const;
     bool is_enclave_encrypted() const;
 
     bool set_memory_protection(uint64_t enclave_base_addr, bool is_after_initialization);
@@ -99,18 +96,18 @@ public:
     bool has_init_section() const;
 
 private:
-    const uint8_t*      m_start_addr;
-    uint64_t            m_len;
-    bin_fmt_t           m_bin_fmt;
-    vector<Section *>   m_sections;
-    const Section*      m_tls_section;
-    uint64_t            m_metadata_offset;
-    uint64_t            m_metadata_block_size;/*multiple metadata block size*/
+    const uint8_t*         m_start_addr;
+    uint64_t               m_len;
+    bin_fmt_t              m_bin_fmt;
+    std::vector<Section *> m_sections;
+    const Section*         m_tls_section;
+    uint64_t               m_metadata_offset;
+    uint64_t               m_metadata_block_size;/*multiple metadata block size*/
 
-    ElfW(Dyn)           m_dyn_info[DT_NUM + DT_ADDRNUM];
+    ElfW(Dyn)              m_dyn_info[DT_NUM + DT_ADDRNUM];
 
     // A map from symbol name to its RVA
-    map<string, uint64_t> m_sym_table;
+    std::map<std::string, uint64_t> m_sym_table;
 };
 
 #endif

--- a/psw/urts/section_info.h
+++ b/psw/urts/section_info.h
@@ -36,8 +36,6 @@
 #include "util.h"
 #include <vector>
 
-using namespace std;
-
 typedef struct _section_info_t
 {
     const uint8_t *raw_data;          //The file pointer to the first page of the section.
@@ -45,7 +43,7 @@ typedef struct _section_info_t
     uint64_t rva;               //The address of the first byte of the section relative to the image base when section is loaded into memory.
     uint64_t virtual_size;      //The total size of the section when loaded into memory.
     si_flags_t flag;            //the attribute of memory region.
-    vector<uint8_t> *bitmap;    //bitmap of the total image page, if bit is 1, the page should be writable.
+    std::vector<uint8_t> *bitmap;    //bitmap of the total image page, if bit is 1, the page should be writable.
     //the first bit of scetion in the bitmap is bitmap[(rva >> PAGE_SHIFT) / 8] & (1 << ((rva >> PAGE_SHIFT) % 8))
     //if the bitmap is NULL, then no restrict on page attribute.
 } section_info_t;

--- a/psw/urts/tcs.cpp
+++ b/psw/urts/tcs.cpp
@@ -102,13 +102,13 @@ CTrustThreadPool::~CTrustThreadPool()
 {
     LockGuard lock(&m_thread_mutex);
     //destroy free tcs list
-    for(vector<CTrustThread *>::iterator it=m_free_thread_vector.begin(); it!=m_free_thread_vector.end(); it++)
+    for(std::vector<CTrustThread *>::iterator it=m_free_thread_vector.begin(); it!=m_free_thread_vector.end(); it++)
     {
         delete *it;
     }
     m_free_thread_vector.clear();
     //destroy unallocated tcs list
-    for(vector<CTrustThread *>::iterator it=m_unallocated_threads.begin(); it!=m_unallocated_threads.end(); it++)
+    for(std::vector<CTrustThread *>::iterator it=m_unallocated_threads.begin(); it!=m_unallocated_threads.end(); it++)
     {
         delete *it;
     }
@@ -133,10 +133,10 @@ CTrustThreadPool::~CTrustThreadPool()
 
 }
 
-void get_thread_set(vector<se_thread_id_t> &thread_vector);
-inline int CTrustThreadPool::find_thread(vector<se_thread_id_t> &thread_vector, se_thread_id_t thread_id)
+void get_thread_set(std::vector<se_thread_id_t> &thread_vector);
+inline int CTrustThreadPool::find_thread(std::vector<se_thread_id_t> &thread_vector, se_thread_id_t thread_id)
 {
-    for(vector<se_thread_id_t>::iterator it=thread_vector.begin(); it!=thread_vector.end(); it++)
+    for(std::vector<se_thread_id_t>::iterator it=thread_vector.begin(); it!=thread_vector.end(); it++)
         if(*it == thread_id)
             return TRUE;
     return FALSE;
@@ -252,9 +252,9 @@ std::vector<CTrustThread *> CTrustThreadPool::get_thread_list()
 {
     LockGuard lock(&m_thread_mutex);
 
-    vector<CTrustThread *> threads;
+    std::vector<CTrustThread *> threads;
 
-    for(vector<CTrustThread *>::iterator it = m_free_thread_vector.begin(); it != m_free_thread_vector.end(); it++)
+    for(std::vector<CTrustThread *>::iterator it = m_free_thread_vector.begin(); it != m_free_thread_vector.end(); it++)
     {
         threads.push_back(*it);
     }
@@ -533,7 +533,7 @@ int CThreadPoolBindMode::garbage_collect()
 
     //if free list is NULL, recycle tcs.
     //get thread id set of current process
-    vector<se_thread_id_t> thread_vector;
+    std::vector<se_thread_id_t> thread_vector;
     get_thread_set(thread_vector);
     //walk through thread cache to see if there is any thread that has exited
     Node<se_thread_id_t, CTrustThread*>* it = m_thread_list, *pre = NULL, *tmp = NULL;

--- a/psw/urts/tcs.h
+++ b/psw/urts/tcs.h
@@ -41,8 +41,6 @@
 #include <vector>
 #include "node.h"
 
-using namespace std;
-
 typedef int (*bridge_fn_t)(const void*);
 
 class CEnclave;
@@ -88,15 +86,15 @@ public:
     bool is_dynamic_thread_exist();
 protected:
     virtual int garbage_collect() = 0;
-    inline int find_thread(vector<se_thread_id_t> &thread_vector, se_thread_id_t thread_id);
+    inline int find_thread(std::vector<se_thread_id_t> &thread_vector, se_thread_id_t thread_id);
     inline CTrustThread * get_free_thread();
     int bind_thread(const se_thread_id_t thread_id, CTrustThread * const trust_thread);
     void unbind_thread(const se_thread_id_t thread_id);
     CTrustThread * get_bound_thread(const se_thread_id_t thread_id);
     void add_to_free_thread_vector(CTrustThread* it);
     
-    vector<CTrustThread *>                  m_free_thread_vector;
-    vector<CTrustThread *>                  m_unallocated_threads; 
+    std::vector<CTrustThread *>                  m_free_thread_vector;
+    std::vector<CTrustThread *>                  m_unallocated_threads; 
     Node<se_thread_id_t, CTrustThread *>    *m_thread_list;
     Mutex                                   m_thread_mutex; //protect thread_cache list. The mutex is recursive.
                                                             //Thread can operate the list when it get the mutex

--- a/sdk/cpprt/memory_manage/new_handler.cpp
+++ b/sdk/cpprt/memory_manage/new_handler.cpp
@@ -68,16 +68,14 @@ namespace std{
     }
 };
 
-using namespace std;
-
 //call new_handl function when  new memory failed
 int  call_newh()
 {
     int ret = 0;
-    sgx_spin_lock(&handler_lock);
-    new_handler handler = new_handl;
+    sgx_spin_lock(&std::handler_lock);
+    std::new_handler handler = std::new_handl;
     //unlock the handler here because new_handl may call set_new_handler again, will cause dead lock.
-    sgx_spin_unlock(&handler_lock);
+    sgx_spin_unlock(&std::handler_lock);
 
     // call new handler
     if ( handler != NULL ){

--- a/sdk/sign_tool/SignTool/elf_helper.h
+++ b/sdk/sign_tool/SignTool/elf_helper.h
@@ -41,11 +41,9 @@
 
 static void dump_textrel(const uint64_t& offset)
 {
-    using namespace std;
-
-    cerr << "warning: TEXTRELs found at offset: "
-         << std::hex << showbase     /* show the '0x' prefix */
-         << offset << endl;
+    std::cerr << "warning: TEXTRELs found at offset: "
+              << std::hex << std::showbase     /* show the '0x' prefix */
+              << offset << std::endl;
 }
 
 template <int N>
@@ -87,13 +85,13 @@ public:
 
     static bool dump_textrels(BinParser *bp)
     {
-        vector<uint64_t> offsets;
+        std::vector<uint64_t> offsets;
         bool no_rel = true;
         /* The dynamic_cast<> shouldn't fail. */
         elf_parser_t   * p = dynamic_cast<elf_parser_t*>(bp);
         if (p == NULL)
             return no_rel;
-        vector<const char *> sec_names;
+        std::vector<const char *> sec_names;
         p->get_executable_sections(sec_names);
         /* Warn user of TEXTRELs */
         for (unsigned i = 0; i< sec_names.size(); i++)

--- a/sdk/sign_tool/SignTool/manage_metadata.cpp
+++ b/sdk/sign_tool/SignTool/manage_metadata.cpp
@@ -55,7 +55,11 @@
 #include <iomanip>
 #include <fstream>
 
-using namespace tinyxml2;
+using tinyxml2::XML_ERROR_FILE_COULD_NOT_BE_OPENED;
+using tinyxml2::XML_ERROR_FILE_NOT_FOUND;
+using tinyxml2::XML_SUCCESS;
+using tinyxml2::XMLElement;
+using tinyxml2::XMLError;
 
 #define ALIGN_SIZE 0x1000
 
@@ -227,7 +231,7 @@ bool CMetadata::get_time(uint32_t *date)
     if(timeinfo  == NULL)
         return false;
     uint32_t tmp_date = (timeinfo->tm_year+1900)*10000 + (timeinfo->tm_mon+1)*100 + timeinfo->tm_mday;
-    stringstream ss;
+    std::stringstream ss;
     ss<<"0x"<<tmp_date;
     ss>>std::hex>>tmp_date;
     *date = tmp_date;
@@ -513,7 +517,7 @@ bool CMetadata::build_layout_table()
     guard_page.entry.id = LAYOUT_ID_GUARD;
     guard_page.entry.page_count = SE_GUARD_PAGE_SIZE >> SE_PAGE_SHIFT;
 
-    vector<layout_t> thread_layouts;
+    std::vector<layout_t> thread_layouts;
     // heap
     layout.entry.id = LAYOUT_ID_HEAP_MIN;
     layout.entry.page_count = (uint32_t)(m_create_param.heap_min_size >> SE_PAGE_SHIFT);
@@ -702,7 +706,7 @@ bool CMetadata::build_layout_table()
     }
     return true;
 }
-bool CMetadata::build_patch_entries(vector<patch_entry_t> &patches)
+bool CMetadata::build_patch_entries(std::vector<patch_entry_t> &patches)
 {
     uint32_t size = (uint32_t)(patches.size() * sizeof(patch_entry_t));
     patch_entry_t *patch_table = (patch_entry_t *) alloc_buffer_from_metadata(size);
@@ -724,7 +728,7 @@ bool CMetadata::build_patch_entries(vector<patch_entry_t> &patches)
 bool CMetadata::build_patch_table()
 {
     const uint8_t *base_addr = (const uint8_t *)m_parser->get_start_addr();
-    vector<patch_entry_t> patches;
+    std::vector<patch_entry_t> patches;
     patch_entry_t patch;
     memset(&patch, 0, sizeof(patch));
 

--- a/sdk/sign_tool/SignTool/manage_metadata.h
+++ b/sdk/sign_tool/SignTool/manage_metadata.h
@@ -100,7 +100,7 @@ private:
     bool build_patch_table();
     bool update_layout_entries();
     bool build_layout_entries();
-    bool build_patch_entries(vector<patch_entry_t> &patches);
+    bool build_patch_entries(std::vector<patch_entry_t> &patches);
 
     layout_entry_t *get_entry_by_id(uint16_t id);
     bool build_tcs_template(tcs_t *tcs);
@@ -113,7 +113,7 @@ private:
     metadata_t *m_metadata;
     BinParser *m_parser;
     create_param_t m_create_param;
-    vector <layout_t> m_layouts;
+    std::vector <layout_t> m_layouts;
     uint64_t m_rva;
     uint32_t m_gd_size;
     uint8_t *m_gd_template;

--- a/sdk/simulation/SEConfigureCPUSVN/linux/config_cpusvn.cpp
+++ b/sdk/simulation/SEConfigureCPUSVN/linux/config_cpusvn.cpp
@@ -49,17 +49,15 @@
 #include <string>
 #include <sstream>
 
-using namespace std;
-
-static void convert_cpusvn_to_string(sgx_cpu_svn_t &cpusvn, string &str)
+static void convert_cpusvn_to_string(sgx_cpu_svn_t &cpusvn, std::string &str)
 {
     uint32_t buffer[4];
     memcpy_s(&buffer, sizeof(uint32_t)*4, &cpusvn, sizeof(sgx_cpu_svn_t));
-    stringstream ss;
+    std::stringstream ss;
     for(int i=0; i<4; i++)
     {
         buffer[i] = __builtin_bswap32(buffer[i]);
-        ss<<hex<<buffer[i];
+        ss<<std::hex<<buffer[i];
     }
     str = ss.str();
     return;
@@ -82,7 +80,7 @@ static bool modify_cpusvn(action_t act, const char* file_path, sgx_cpu_svn_t &cp
     assert(file_path != NULL);
 
     bool ret = false;
-    string cpusvn_str = "";
+    std::string cpusvn_str = "";
     switch(act)
     {
     case ACTION_RESET:

--- a/sdk/tlibcxx/include/ext/__hash
+++ b/sdk/tlibcxx/include/ext/__hash
@@ -17,12 +17,11 @@
 #include <cstring>
 
 namespace __gnu_cxx {
-using namespace std;
 
 template <typename _Tp> struct _LIBCPP_TYPE_VIS_ONLY hash { };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<const char*>
-    : public unary_function<const char*, size_t>
+    : public std::unary_function<const char*, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(const char *__c) const _NOEXCEPT
@@ -32,7 +31,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<const char*>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<char *>
-    : public unary_function<char*, size_t>
+    : public std::unary_function<char*, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(char *__c) const _NOEXCEPT
@@ -42,7 +41,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<char *>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<char>
-    : public unary_function<char, size_t>
+    : public std::unary_function<char, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(char __c) const _NOEXCEPT
@@ -52,7 +51,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<char>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<signed char>
-    : public unary_function<signed char, size_t>
+    : public std::unary_function<signed char, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(signed char __c) const _NOEXCEPT
@@ -62,7 +61,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<signed char>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<unsigned char>
-    : public unary_function<unsigned char, size_t>
+    : public std::unary_function<unsigned char, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(unsigned char __c) const _NOEXCEPT
@@ -72,7 +71,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<unsigned char>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<short>
-    : public unary_function<short, size_t>
+    : public std::unary_function<short, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(short __c) const _NOEXCEPT
@@ -82,7 +81,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<short>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<unsigned short>
-    : public unary_function<unsigned short, size_t>
+    : public std::unary_function<unsigned short, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(unsigned short __c) const _NOEXCEPT
@@ -92,7 +91,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<unsigned short>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<int>
-    : public unary_function<int, size_t>
+    : public std::unary_function<int, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(int __c) const _NOEXCEPT
@@ -102,7 +101,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<int>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<unsigned int>
-    : public unary_function<unsigned int, size_t>
+    : public std::unary_function<unsigned int, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(unsigned int __c) const _NOEXCEPT
@@ -112,7 +111,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<unsigned int>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<long>
-    : public unary_function<long, size_t>
+    : public std::unary_function<long, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(long __c) const _NOEXCEPT
@@ -122,7 +121,7 @@ template <> struct _LIBCPP_TYPE_VIS_ONLY hash<long>
 };
 
 template <> struct _LIBCPP_TYPE_VIS_ONLY hash<unsigned long>
-    : public unary_function<unsigned long, size_t>
+    : public std::unary_function<unsigned long, size_t>
 {
     _LIBCPP_INLINE_VISIBILITY
     size_t operator()(unsigned long __c) const _NOEXCEPT

--- a/sdk/tlibcxx/include/ext/hash_map
+++ b/sdk/tlibcxx/include/ext/hash_map
@@ -220,10 +220,8 @@ template <class Key, class T, class Hash, class Pred, class Alloc>
 
 namespace __gnu_cxx {
 
-using namespace std;
-
 template <class _Tp, class _Hash,
-          bool = is_empty<_Hash>::value && !__libcpp_is_final<_Hash>::value
+          bool = std::is_empty<_Hash>::value && !__libcpp_is_final<_Hash>::value
         >
 class __hash_map_hasher
     : private _Hash
@@ -257,7 +255,7 @@ public:
 };
 
 template <class _Tp, class _Pred,
-          bool = is_empty<_Pred>::value && !__libcpp_is_final<_Pred>::value
+          bool = std::is_empty<_Pred>::value && !__libcpp_is_final<_Pred>::value
          >
 class __hash_map_equal
     : private _Pred
@@ -308,7 +306,7 @@ template <class _Alloc>
 class __hash_map_node_destructor
 {
     typedef _Alloc                              allocator_type;
-    typedef allocator_traits<allocator_type>    __alloc_traits;
+    typedef std::allocator_traits<allocator_type>    __alloc_traits;
     typedef typename __alloc_traits::value_type::__node_value_type value_type;
 public:
     typedef typename __alloc_traits::pointer    pointer;
@@ -372,7 +370,7 @@ class _LIBCPP_TYPE_VIS_ONLY __hash_map_iterator
     typedef typename _HashIterator::value_type::second_type      mapped_type;
 public:
     typedef forward_iterator_tag                                 iterator_category;
-    typedef pair<key_type, mapped_type>                          value_type;
+    typedef std::pair<key_type, mapped_type>                          value_type;
     typedef typename _HashIterator::difference_type              difference_type;
     typedef value_type&                                          reference;
     typedef typename __rebind_pointer<typename _HashIterator::pointer, value_type>::type
@@ -417,7 +415,7 @@ class _LIBCPP_TYPE_VIS_ONLY __hash_map_const_iterator
     typedef typename _HashIterator::value_type::second_type      mapped_type;
 public:
     typedef forward_iterator_tag                                 iterator_category;
-    typedef pair<key_type, mapped_type>                          value_type;
+    typedef std::pair<key_type, mapped_type>                          value_type;
     typedef typename _HashIterator::difference_type              difference_type;
     typedef const value_type&                                    reference;
     typedef typename __rebind_pointer<typename _HashIterator::pointer, const value_type>::type
@@ -461,7 +459,7 @@ public:
 };
 
 template <class _Key, class _Tp, class _Hash = hash<_Key>, class _Pred = equal_to<_Key>,
-          class _Alloc = allocator<pair<const _Key, _Tp> > >
+          class _Alloc = std::allocator<std::pair<const _Key, _Tp> > >
 class _LIBCPP_TYPE_VIS_ONLY hash_map
 {
 public:
@@ -472,15 +470,15 @@ public:
     typedef _Hash                                          hasher;
     typedef _Pred                                          key_equal;
     typedef _Alloc                                         allocator_type;
-    typedef pair<const key_type, mapped_type>              value_type;
+    typedef std::pair<const key_type, mapped_type>              value_type;
     typedef value_type&                                    reference;
     typedef const value_type&                              const_reference;
 
 private:
-    typedef pair<key_type, mapped_type>                    __value_type;
+    typedef std::pair<key_type, mapped_type>                    __value_type;
     typedef __hash_map_hasher<__value_type, hasher>   __hasher;
     typedef __hash_map_equal<__value_type, key_equal> __key_equal;
-    typedef typename __rebind_alloc_helper<allocator_traits<allocator_type>, __value_type>::type __allocator_type;
+    typedef typename __rebind_alloc_helper<std::allocator_traits<allocator_type>, __value_type>::type __allocator_type;
 
     typedef __hash_table<__value_type, __hasher,
                          __key_equal,  __allocator_type>   __table;
@@ -494,7 +492,7 @@ private:
     typedef typename __table::__node                       __node;
     typedef __hash_map_node_destructor<__node_allocator>   _Dp;
     typedef unique_ptr<__node, _Dp>                         __node_holder;
-    typedef allocator_traits<allocator_type>               __alloc_traits;
+    typedef std::allocator_traits<allocator_type>               __alloc_traits;
 public:
     typedef typename __alloc_traits::pointer         pointer;
     typedef typename __alloc_traits::const_pointer   const_pointer;
@@ -544,7 +542,7 @@ public:
     const_iterator end()    const {return __table_.end();}
 
     _LIBCPP_INLINE_VISIBILITY
-    pair<iterator, bool> insert(const value_type& __x)
+    std::pair<iterator, bool> insert(const value_type& __x)
         {return __table_.__insert_unique(__x);}
     _LIBCPP_INLINE_VISIBILITY
     iterator insert(const_iterator, const value_type& __x) {return insert(__x).first;}
@@ -579,10 +577,10 @@ public:
     _LIBCPP_INLINE_VISIBILITY
     size_type count(const key_type& __k) const {return __table_.__count_unique(__k);}
     _LIBCPP_INLINE_VISIBILITY
-    pair<iterator, iterator>             equal_range(const key_type& __k)
+    std::pair<iterator, iterator>             equal_range(const key_type& __k)
         {return __table_.__equal_range_unique(__k);}
     _LIBCPP_INLINE_VISIBILITY
-    pair<const_iterator, const_iterator> equal_range(const key_type& __k) const
+    std::pair<const_iterator, const_iterator> equal_range(const key_type& __k) const
         {return __table_.__equal_range_unique(__k);}
 
     mapped_type& operator[](const key_type& __k);
@@ -692,7 +690,7 @@ hash_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator[](const key_type& __k)
     if (__i != end())
         return __i->second;
     __node_holder __h = __construct_node(__k);
-    pair<iterator, bool> __r = __table_.__node_insert_unique(__h.get());
+    std::pair<iterator, bool> __r = __table_.__node_insert_unique(__h.get());
     __h.release();
     return __r.first->second;
 }
@@ -735,7 +733,7 @@ operator!=(const hash_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
 }
 
 template <class _Key, class _Tp, class _Hash = hash<_Key>, class _Pred = equal_to<_Key>,
-          class _Alloc = allocator<pair<const _Key, _Tp> > >
+          class _Alloc = std::allocator<std::pair<const _Key, _Tp> > >
 class _LIBCPP_TYPE_VIS_ONLY hash_multimap
 {
 public:
@@ -746,15 +744,15 @@ public:
     typedef _Hash                                          hasher;
     typedef _Pred                                          key_equal;
     typedef _Alloc                                         allocator_type;
-    typedef pair<const key_type, mapped_type>              value_type;
+    typedef std::pair<const key_type, mapped_type>              value_type;
     typedef value_type&                                    reference;
     typedef const value_type&                              const_reference;
 
 private:
-    typedef pair<key_type, mapped_type>                    __value_type;
+    typedef std::pair<key_type, mapped_type>                    __value_type;
     typedef __hash_map_hasher<__value_type, hasher>   __hasher;
     typedef __hash_map_equal<__value_type, key_equal> __key_equal;
-    typedef typename __rebind_alloc_helper<allocator_traits<allocator_type>, __value_type>::type __allocator_type;
+    typedef typename __rebind_alloc_helper<std::allocator_traits<allocator_type>, __value_type>::type __allocator_type;
 
     typedef __hash_table<__value_type, __hasher,
                          __key_equal,  __allocator_type>   __table;
@@ -766,7 +764,7 @@ private:
     typedef typename __table::__node                       __node;
     typedef __hash_map_node_destructor<__node_allocator>   _Dp;
     typedef unique_ptr<__node, _Dp>                         __node_holder;
-    typedef allocator_traits<allocator_type>               __alloc_traits;
+    typedef std::allocator_traits<allocator_type>               __alloc_traits;
 public:
     typedef typename __alloc_traits::pointer         pointer;
     typedef typename __alloc_traits::const_pointer   const_pointer;
@@ -851,10 +849,10 @@ public:
     _LIBCPP_INLINE_VISIBILITY
     size_type count(const key_type& __k) const {return __table_.__count_multi(__k);}
     _LIBCPP_INLINE_VISIBILITY
-    pair<iterator, iterator>             equal_range(const key_type& __k)
+    std::pair<iterator, iterator>             equal_range(const key_type& __k)
         {return __table_.__equal_range_multi(__k);}
     _LIBCPP_INLINE_VISIBILITY
-    pair<const_iterator, const_iterator> equal_range(const key_type& __k) const
+    std::pair<const_iterator, const_iterator> equal_range(const key_type& __k) const
         {return __table_.__equal_range_multi(__k);}
 
     _LIBCPP_INLINE_VISIBILITY
@@ -956,7 +954,7 @@ operator==(const hash_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
         return false;
     typedef typename hash_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::const_iterator
                                                                  const_iterator;
-    typedef pair<const_iterator, const_iterator> _EqRng;
+    typedef std::pair<const_iterator, const_iterator> _EqRng;
     for (const_iterator __i = __x.begin(), __ex = __x.end(); __i != __ex;)
     {
         _EqRng __xeq = __x.equal_range(__i->first);

--- a/sdk/tlibcxx/include/ext/hash_set
+++ b/sdk/tlibcxx/include/ext/hash_set
@@ -208,10 +208,8 @@ template <class Value, class Hash, class Pred, class Alloc>
 
 namespace __gnu_cxx {
 
-using namespace std;
-
-template <class _Value, class _Hash = hash<_Value>, class _Pred = equal_to<_Value>,
-          class _Alloc = allocator<_Value> >
+template <class _Value, class _Hash = std::hash<_Value>, class _Pred = std::equal_to<_Value>,
+          class _Alloc = std::allocator<_Value> >
 class _LIBCPP_TYPE_VIS_ONLY hash_set
 {
 public:


### PR DESCRIPTION
Header files that contain "using namespace std;" do not work well in
codebases that have custom implementations for common classes such as
"string". This is a C++ Core guideline (SF.7).

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>