### PR TITLE
Resolves issue when cleaning a trusted static library.

### DIFF
--- a/Linux_SGXEclipsePlugin/build_directory/plugins/com.intel.sgx/templates/sgx/SGXTrustedStaticLibrary/makefiles/common/Makefile.without_app
+++ b/Linux_SGXEclipsePlugin/build_directory/plugins/com.intel.sgx/templates/sgx/SGXTrustedStaticLibrary/makefiles/common/Makefile.without_app
@@ -4,5 +4,5 @@ all:
 
 clean:
 	$(MAKE) -f sgx_u.mk clean
-	$(MAKE) -f sgx_t.mk clean
+	$(MAKE) -f sgx_t_static.mk clean
 


### PR DESCRIPTION
Before:

make[1]: Entering directory '/home/username/eclipse-workspace/sgx-learning/sgx/trustedlib_trustedlib'
make[1]: sgx_t.mk: No such file or directory
make[1]: *** No rule to make target 'sgx_t.mk'.  Stop.