### PR TITLE
Fix uninitialized launch tokens, breaking simulation mode

### DIFF
--- a/SampleCode/LocalAttestation/App/App.cpp
+++ b/SampleCode/LocalAttestation/App/App.cpp
@@ -73,7 +73,7 @@ uint32_t load_enclaves()
 {
     uint32_t enclave_temp_no;
     int ret, launch_token_updated;
-    sgx_launch_token_t launch_token;
+    sgx_launch_token_t launch_token = {0};
 
     enclave_temp_no = 0;
 

--- a/SampleCode/SealedData/DRM_app/ReplayProtectedDRM.h
+++ b/SampleCode/SealedData/DRM_app/ReplayProtectedDRM.h
@@ -61,7 +61,7 @@ public:
 private:
     uint8_t  sealed_activity_log[sealed_activity_log_length];
     sgx_enclave_id_t enclave_id;
-    sgx_launch_token_t launch_token;
+    sgx_launch_token_t launch_token = {0};
 
 };
 

--- a/SampleCode/SealedData/DRM_app/TimeBasedDRM.h
+++ b/SampleCode/SealedData/DRM_app/TimeBasedDRM.h
@@ -54,6 +54,6 @@ public:
 private:
     uint8_t  time_based_policy[time_based_policy_length];
     sgx_enclave_id_t enclave_id;
-    sgx_launch_token_t launch_token;
+    sgx_launch_token_t launch_token = {0};
 };
 


### PR DESCRIPTION
This is a fix for issue #330.

In general, usage of uninitialized variables should be considered as a bug.
