### PR TITLE
Bug fix in launch checker

### DIFF
--- a/psw/urts/launch_checker.cpp
+++ b/psw/urts/launch_checker.cpp
@@ -123,7 +123,7 @@ sgx_status_t SGXLaunchToken::update_launch_token(
     if (force_update_tok ||
             SE_ERROR_INVALID_LAUNCH_TOKEN == chk_launch_token(m_css, m_secs_attr, &m_launch))
     {
-        //status = ::get_launch_token(m_css, m_secs_attr, &m_launch);
+        status = ::get_launch_token(m_css, m_secs_attr, &m_launch);
 
         if (status == SGX_SUCCESS)
             m_launch_updated = true;


### PR DESCRIPTION
The current launch checker misses an essential check on launch token (I guess it's commented out for debug). This forces launch token always updated and results in the inconsistency between launch token design and implementation.

Signed-off-by: Yu Ding <dingelish@gmail.com>