### PR TITLE
Fix overly restrictive ELF format check

### DIFF
--- a/psw/urts/parser/elfparser.cpp
+++ b/psw/urts/parser/elfparser.cpp
@@ -421,7 +421,7 @@ bool validate_segment(const ElfW(Ehdr) *elf_hdr, uint64_t len)
     for (int idx = 0; idx < elf_hdr->e_phnum; idx++, prg_hdr++)
     {
         /* Validate the size of the buffer */
-        if (len < (uint64_t)prg_hdr->p_offset + prg_hdr->p_filesz)
+        if (prg_hdr->p_filesz != 0 && len < (uint64_t)prg_hdr->p_offset + prg_hdr->p_filesz)
             return false;
 
         if (PT_LOAD == prg_hdr->p_type)


### PR DESCRIPTION
In [psw/urts/parser/elfparser.cpp](https://github.com/intel/linux-sgx/blob/master/psw/urts/parser/elfparser.cpp) there is a function `bool validate_segment(const ElfW(Ehdr) *elf_hdr, uint64_t len)` checking the offset and size of a loadable segment to ensure the range falls within the ELF file, with the following code
```
/* Validate the size of the buffer */
if (len < (uint64_t)prg_hdr->p_offset + prg_hdr->p_filesz)
    return false;
``` 
This check should only be performed when the segment file size is greater than zero. If the segment has zero file size, say, a segment holding only the .bss section, there will never be buffer overread regardless of the value of prg_hdr->p_offset.