### PR TITLE
Fix setcontext.S parse error

### DIFF
--- a/sdk/trts/linux/x86_64/setcontext.S
+++ b/sdk/trts/linux/x86_64/setcontext.S
@@ -29,7 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #if defined __linux__
 #include <asm/unistd.h>
 #define	SIG_SETMASK   2
-#define	SIGSET_BYTE_SIZE   (64/8)
+#define	SIGSET_BYTE_SIZE   8
 #elif defined __FreeBSD__
 #include <sys/syscall.h>
 #endif


### PR DESCRIPTION
When this file is parsed on its own for syntactic correctness (via
bazel's parse_headers feature), the use of SIGSET_BYTE_SIZE in
$SIGSET_BYTE_SIZE fails to parse as $(64/8). This simplifies the
expression so that $8 is syntactically correct.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>