### PR TITLE
Update OpenSSL version used in Tcrypto to 1.1.0j.

### DIFF
--- a/external/sgxssl/prepare_sgxssl.sh
+++ b/external/sgxssl/prepare_sgxssl.sh
@@ -32,17 +32,17 @@
 
 top_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 openssl_out_dir=$top_dir/openssl_source
-openssl_ver_name=openssl-1.1.0i
+openssl_ver_name=openssl-1.1.0j
 sgxssl_github_archive=https://github.com/01org/intel-sgx-ssl/archive
-sgxssl_ver_name=v2.4
-sgxssl_ver=2.4
+sgxssl_ver_name=v2.4.1
+sgxssl_ver=2.4.1
 build_script=$top_dir/Linux/build_openssl.sh
 server_url_path=https://www.openssl.org/source/
 full_openssl_url=$server_url_path/$openssl_ver_name.tar.gz
 full_openssl_url_old=$server_url_path/old/1.1.0/$openssl_ver_name.tar.gz
 
-sgxssl_chksum=85e7e6a490ee495623db02b5b8655141877bc25e22c6e0fa4fb937175514e911
-openssl_chksum=ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99
+sgxssl_chksum=f2233e077201f61ce8a07cd7481fca4509774bc3b446b59273b5b224d8aa5a7b
+openssl_chksum=31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246
 rm -f check_sum_sgxssl.txt check_sum_openssl.txt
 if [ ! -f $build_script ]; then
 	wget $sgxssl_github_archive/$sgxssl_ver_name.zip -P $top_dir || exit 1

--- a/sdk/tlibcrypto/sgxssl/sgx_rsa_encryption.cpp
+++ b/sdk/tlibcrypto/sgxssl/sgx_rsa_encryption.cpp
@@ -181,6 +181,12 @@ sgx_status_t sgx_create_rsa_priv2_key(int mod_size, int exp_size, const unsigned
 		//
 		d = BN_dup(n);
 		NULL_BREAK(d);
+        
+		//select algorithms with an execution time independent of the respective numbers, to avoid exposing sensitive information to timing side-channel attacks.
+		//
+		BN_set_flags(d, BN_FLG_CONSTTIME);
+		BN_set_flags(e, BN_FLG_CONSTTIME);
+
 		if (!BN_sub(d, d, p) || !BN_sub(d, d, q) || !BN_add_word(d, 1) || !BN_mod_inverse(d, e, d, tmp_ctx)) {
 			break;
 		}


### PR DESCRIPTION
This version mitigates a side channel attack on ECDSA.

Signed-off-by: Kryeem, Alaa <alaa.kryeem@intel.com>