### PR TITLE
Fix signature verification error in sgx_report_attestation_status and a make dependency problem

### DIFF
--- a/psw/ae/aesm_service/source/upse/u_certificate_provisioning.cpp
+++ b/psw/ae/aesm_service/source/upse/u_certificate_provisioning.cpp
@@ -700,15 +700,21 @@ ae_error_t pib_verify_signature(platform_info_blob_wrapper_t& piBlobWrapper)
         //BREAK_IF_TRUE((sizeof(publicKey) != sizeof(s_pib_pub_key_big_endian)), ae_err, AE_FAILURE);
         //BREAK_IF_TRUE((sizeof(signature) != sizeof(piBlobWrapper.platform_info_blob.signature)), ae_err, AE_FAILURE);
 
+        // convert the public key to little endian
         if(0!=memcpy_s(&publicKey, sizeof(publicKey), s_pib_pub_key_big_endian, sizeof(s_pib_pub_key_big_endian))){
             ae_err = AE_FAILURE;
             break;
         }
+        SwapEndian_32B(((uint8_t*)&publicKey) +  0);
+        SwapEndian_32B(((uint8_t*)&publicKey) + 32);
 
+        // convert the signature to little endian
         if(0!=memcpy_s(&signature, sizeof(signature), &piBlobWrapper.platform_info_blob.signature, sizeof(piBlobWrapper.platform_info_blob.signature))){
             ae_err = AE_FAILURE;
             break;
         }
+        SwapEndian_32B(((uint8_t*)&signature) +  0);
+        SwapEndian_32B(((uint8_t*)&signature) + 32);
 
         sgx_status = sgx_ecc256_open_context(&ecc_handle);
         BREAK_IF_TRUE((SGX_SUCCESS != sgx_status), ae_err, AE_FAILURE);

--- a/sdk/trts/Makefile
+++ b/sdk/trts/Makefile
@@ -71,7 +71,7 @@ $(OBJS2): %.o: %.cpp
 	$(CXX) -c $(TCXXFLAGS) $(CPPFLAGS) -fPIC $< -o $@
 
 .PHONY: elf_parser
-elf_parser:
+elf_parser: $(OBJS)
 	$(MAKE) -C linux
 
 .PHONY: clean


### PR DESCRIPTION
4baa19d
In 2.4.0, sgx_report_attestation_status always returns `SGX_ERROR_INVALID_PARAMETER` due to oal_map_result [returns](https://github.com/intel/linux-sgx/blob/bcd3c27a6ea204a0dea1fd7cb00ef4880226d87d/psw/uae_service/sgx_uae_service.cpp#L280) `AESM_PLATFORM_INFO_BLOB_INVALID_SIG`. The problem is caused by a [change](https://github.com/intel/linux-sgx/commit/28817533cc3868892b26d0c02378d79def4a681a#diff-2dfb4adda56d7392d03682a552809d6eL703) in u_certificate_provisioning.cpp, removing essential endian conversion. This commit aims at reverting this change and making sgx_report_attestation_status works again.

One test case on my testbed, which accepted by 2.3.1 but denied by 2.4.0: 1502006500000800000202020401800000000000000000000007000006000000020000000000000B0D292FE7F0F37C075567E227A454318D29A3E94F035693794FADECD6C31606DE989858BF7FB718A096B52A90EFCD50270C9A0A2F4500CFAC159DD44EAA2C014179

This case is accepted by aesm_service with the given patch.

dd54bf1
`make -j` the entire SDK always results in an error message about `cannot find utility` from sgx_random_buffers.h when compiling trts_ecall.cpp. I found that this is caused by doing `make` in `sdk/trts/linux` before `sdk/trts`. This patch fixes the problem by an additional dependency.

Signed-off-by: Yu Ding <dingelish@gmail.com>