### PR TITLE
Remove unused ill-defined 'storage' type field

### DIFF
--- a/common/inc/sgx_random_buffers.h
+++ b/common/inc/sgx_random_buffers.h
@@ -249,9 +249,6 @@ struct alignas(A)randomly_placed_buffer
         free(ptr);
     }
 
-    template <unsigned C = 1>
-    using storage = char[size(C)] alignas(A);
-
 private:
     struct alignas(A)_T_instantiator_
     {


### PR DESCRIPTION
The templated "storage" field in randomly_placed_buffer is uses alignas
in an undefined way. The field is also not used, so this change removes
it.