### PR TITLE
Refuse to build when there are spaces in the project root path

### DIFF
--- a/buildenv.mk
+++ b/buildenv.mk
@@ -46,6 +46,10 @@ my-dir = $(realpath $(call parent-dir,$(lastword $(MAKEFILE_LIST))))
 
 
 ROOT_DIR              := $(call my-dir)
+ifneq ($(words $(subst :, ,$(ROOT_DIR))), 1)
+  $(error main directory cannot contain spaces nor colons)
+endif
+
 COMMON_DIR            := $(ROOT_DIR)/common
 LINUX_EXTERNAL_DIR    := $(ROOT_DIR)/external
 LINUX_PSW_DIR         := $(ROOT_DIR)/psw


### PR DESCRIPTION
When there are spaces in the ROOT_DIR, some make targets fail because
paths are not properly quoted:

```
$ make -C sdk/ USE_OPT_LIBS=1
make[1]: Entering directory '/home/ao2/dir with spaces/linux-sgx/sdk'
Makefile.opt_lib:133: warning: overriding recipe for target '/home/ao2/dir'
Makefile.opt_lib:88: warning: ignoring old recipe for target '/home/ao2/dir'
Makefile.opt_lib:133: warning: overriding recipe for target 'with'
Makefile.opt_lib:88: warning: ignoring old recipe for target 'with'
...
ERROR: Please run 'download_prebuilt.sh' to download the prebuilt optimized libraries before compiling.
Exiting......
/bin/sh: 1: exit: Illegal number: -2
make[1]: *** [Makefile:49: opt_check_failed] Error 2
make[1]: Leaving directory '/home/ao2/dir with spaces/linux-sgx/sdk'
make: *** [Makefile:41: sdk] Error 2
```

Instead of fixing all the occurrences of the problem, just refuse to
build when there are spaces or colons in the build path.

This is also what kbuild in the linux kernel does:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Makefile?h=v5.0#n126