### PR TITLE
Typo on edger8r *_u.h generated header file

### DIFF
--- a/sdk/edger8r/linux/CodeGen.ml
+++ b/sdk/edger8r/linux/CodeGen.ml
@@ -647,7 +647,7 @@ let gen_uheader_preemble (guard: string) (inclist: string)=
 #include <wchar.h>\n\
 #include <stddef.h>\n\
 #include <string.h>\n\
-#include \"sgx_edger8r.h\" /* for sgx_satus_t etc. */\n" in
+#include \"sgx_edger8r.h\" /* for sgx_status_t etc. */\n" in
     grd_hdr ^ inc_exp ^ "\n" ^ inclist ^ "\n" ^ common_macros
 
 let ms_writer out_chan ec =


### PR DESCRIPTION
This pull request fixes typo on edger8r *_u.h generated header file

- "sgx_satus_t" -> "sgx_status_t"

Signed-off-by: Fábio Silva <fabio.fernando.osilva@gmail.com>