### PR TITLE
Change rdrand license entry to 3-clause BSD

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -777,132 +777,32 @@ SUCH DAMAGE.
 
 10. rdrand
 
-Intel Sample Source Code license.
+BSD License
 
-This license governs use of the accompanying software. By installing or
-copying all or any part of the software components in this package, you
-("you" or "Licensee") agree to the terms of this agreement. Do
-not install or copy the software until you have carefully read and
-agreed to the following terms and conditions. If you do not agree to the
-terms of this agreement, promptly return the software to Intel
-Corporation ("Intel").
+Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
 
-1. Definitions:
-
-A. "Materials" are defined as the software (including the
-Redistributables and Sample Source as defined herein), documentation,
-and other materials, including any updates and upgrade thereto, that are
-provided to you under this Agreement.
-
-B. "Redistributables" are the files listed in the "redist.txt" file that
-is included in the Materials or are otherwise clearly identified as
-redistributable files by Intel.
-
-C. "Sample Source" is the source code file(s) that: (i)
-demonstrate(s) certain functions for particular purposes; (ii) are
-identified as sample source code; and (iii) are provided hereunder in
-source code form.
-
-D. "Intel's Licensed Patent Claims" means those claims of
-Intel's patents that (a) are infringed by the Sample Source or
-Redistributables, alone and not in combination, in their unmodified
-form, as furnished by Intel to Licensee and (b) Intel has the right to
-license.
-
-2. License Grant: Subject to all of the terms and conditions of this
-Agreement:
-
-A. Intel grants to you a non-exclusive, non-assignable, copyright
-license to use the Material for your internal development purposes only.
-
-B. Intel grants to you a non-exclusive, non-assignable copyright license
-to reproduce the Sample Source, prepare derivative works of the Sample
-Source and distribute the Sample Source or any derivative works thereof
-that you create, as part of the product or application you develop using
-the Materials.
-
-C. Intel grants to you a non-exclusive, non-assignable copyright license
-to distribute the Redistributables, or any portions thereof, as part of
-the product or application you develop using the Materials.
-
-D. Intel grants Licensee a non-transferable, non-exclusive, worldwide,
-non-sublicenseable license under Intel's Licensed Patent Claims to
-make, use, sell, and import the Sample Source and the Redistributables.
-
-3. Conditions and Limitations:
-
-A. This license does not grant you any rights to use Intel's name,
-logo or trademarks.
-
-B. Title to the Materials and all copies thereof remain with Intel. The
-Materials are copyrighted and are protected by United States copyright
-laws. You will not remove any copyright notice from the Materials. You
-agree to prevent any unauthorized copying of the Materials. Except as
-expressly provided herein, Intel does not grant any express or implied
-right to you under Intel patents, copyrights, trademarks, or trade
-secret information.
-
-C. You may NOT: (i) use or copy the Materials except as provided in this
-Agreement; (ii) rent or lease the Materials to any third party; (iii)
-assign this Agreement or transfer the Materials without the express
-written consent of Intel; (iv) modify, adapt, or translate the Materials
-in whole or in part except as provided in this Agreement; (v) reverse
-engineer, decompile, or disassemble the Materials not provided to you in
-source code form; or (vii) distribute, sublicense or transfer the source
-code form of any components of the Materials and derivatives thereof to
-any third party except as provided in this Agreement.
-
-D. Platform Limitation - The licenses granted in section 2 extend only
-to the software or derivative works that you create that run directly on
-a Microsoft Windows operating system product, Microsoft run-time
-technology (such as the .NET Framework or Silverlight), or Microsoft
-application platform (such as Microsoft Office or Microsoft Dynamics).
-
-4. No Warranty:
-
-THE MATERIALS ARE PROVIDED "AS IS". INTEL DISCLAIMS ALL EXPRESS OR
-IMPLIED WARRANTIES WITH RESPECT TO THEM, INCLUDING ANY IMPLIED
-WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, AND FITNESS FOR ANY
-PARTICULAR PURPOSE.
-
-5. LIMITATION OF LIABILITY: NEITHER INTEL NOR ITS SUPPLIERS SHALL BE
-LIABLE FOR ANY DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION,
-DAMAGES FOR LOSS OF BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF
-BUSINESS INFORMATION, OR OTHER LOSS) ARISING OUT OF THE USE OF OR
-INABILITY TO USE THE SOFTWARE, EVEN IF INTEL HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES. BECAUSE SOME JURISDICTIONS PROHIBIT THE
-EXCLUSION OR LIMITATION OF LIABILITY FOR CONSEQUENTIAL OR INCIDENTAL
-DAMAGES, THE ABOVE LIMITATION MAY NOT APPLY TO YOU.
-
-6. USER SUBMISSIONS: You agree that any material, information or other
-communication, including all data, images, sounds, text, and other
-things embodied therein, you transmit or post to an Intel website or
-provide to Intel under this Agreement will be considered
-non-confidential ("Communications"). Intel will have no confidentiality
-obligations with respect to the Communications. You agree that Intel and
-its designees will be free to copy, modify, create derivative works,
-publicly display, disclose, distribute, license and sublicense through
-multiple tiers of distribution and licensees, incorporate and otherwise
-use the Communications, including derivative works thereto, for any and
-all commercial or non-commercial purposes
-
-7. TERMINATION OF THIS LICENSE: This Agreement becomes effective on the
-date you accept this Agreement and will continue until terminated as
-provided for in this Agreement. Intel may terminate this license at any
-time if you are in breach of any of its terms and conditions. Upon
-termination, you will immediately return to Intel or destroy the
-Materials and all copies thereof.
-
-8. U.S. GOVERNMENT RESTRICTED RIGHTS: The Materials are provided with
-"RESTRICTED RIGHTS". Use, duplication or disclosure by the Government is
-subject to restrictions set forth in FAR52.227-14 and DFAR252.227-7013
-et seq. or its successor. Use of the Materials by the Government
-constitutes acknowledgment of Intel's rights in them.
-
-9. APPLICABLE LAWS: Any claim arising under or relating to this
-Agreement shall be governed by the internal substantive laws of the
-State of Delaware, without regard to principles of conflict of laws. You
-may not export the Materials in violation of applicable export laws.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+-       Redistributions of source code must retain the above copyright notice,
+		this list of conditions and the following disclaimer.
+-       Redistributions in binary form must reproduce the above copyright 
+		notice, this list of conditions and the following disclaimer in the
+		documentation and/or other materials provided with the distribution.
+-       Neither the name of Intel Corporation nor the names of its contributors
+		may be used to endorse or promote products derived from this software
+		without specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
 
 
 


### PR DESCRIPTION
The headers for all rdrand sources reference 3-clause BSD, and the Intel
Sample Source Code License is almost assuredly too restrictive. For one,
the license restricts the platform to Windows, which this project does
not support. This poses a risk to companies that wish to use Intel SGX SDK on Linux.

I could not find the rdrand original sources, just DRNG, which is rdrand + rdseed. I asked about the license on the website (https://software.intel.com/en-us/articles/the-drng-library-and-manual#), but apparently it's too old for the owners to want to answer. Since Intel Corporation published the original sources, and linux-sgx is also an Intel Corporation-owned project, I hope that y'all can reach an agreement internally to relicense under what appears to be the intended permissive BSD license.