### PR TITLE
fix Remote Attestation sample code

### DIFF
--- a/SampleCode/RemoteAttestation/isv_app/isv_app.cpp
+++ b/SampleCode/RemoteAttestation/isv_app/isv_app.cpp
@@ -716,8 +716,11 @@ int main(int argc, char* argv[])
 
 
         ra_free_network_response_buffer(p_msg0_resp_full);
+        p_msg0_resp_full = NULL;
         ra_free_network_response_buffer(p_msg2_full);
+        p_msg2_full = NULL;
         ra_free_network_response_buffer(p_att_result_msg_full);
+        p_att_result_msg_full = NULL;
 
         // p_msg3 is malloc'd by the untrusted KE library. App needs to free.
         SAFE_FREE(p_msg3);

--- a/SampleCode/RemoteAttestation/service_provider/service_provider.cpp
+++ b/SampleCode/RemoteAttestation/service_provider/service_provider.cpp
@@ -244,7 +244,8 @@ int sp_ra_proc_msg0_req(const sample_ra_msg0_t *p_msg0,
         msg0_resp_size = (uint32_t)sizeof(g_epid_unlinkable_att_key_id_list);
     }
 
-    p_msg0_resp_full = (ra_samp_response_header_t*)malloc(msg0_resp_size);
+    p_msg0_resp_full = (ra_samp_response_header_t*)malloc(msg0_resp_size
+        + sizeof(ra_samp_response_header_t));
     if(!p_msg0_resp_full)
     {
         fprintf(stderr, "\nError, out of memory in [%s].", __FUNCTION__);
@@ -252,7 +253,7 @@ int sp_ra_proc_msg0_req(const sample_ra_msg0_t *p_msg0,
     }
     else
     {
-        memset(p_msg0_resp_full, 0, msg0_resp_size);
+        memset(p_msg0_resp_full, 0, msg0_resp_size + sizeof(ra_samp_response_header_t));
 
         if (g_return_ecdsa_att_key_id)
         {


### PR DESCRIPTION
Fix two bugs that can cause core dump in Remote Attestation sample code.

p_msg0_resp_full is not allocated with correct size.
message pointer is not NULL before second while loop, causes double free.

Signed-off-by: Li, Xun <xun.li@intel.com>