### PR TITLE
Handle new PIB flag in AESM to close #306

### DIFF
--- a/psw/ae/aesm_service/source/bundles/local_pseop_service_bundle/platform_info_facility.cpp
+++ b/psw/ae/aesm_service/source/bundles/local_pseop_service_bundle/platform_info_facility.cpp
@@ -223,6 +223,20 @@ bool PlatformInfoLogic::cpu_svn_out_of_date(const platform_info_blob_wrapper_t* 
 
     return retVal;
 }
+
+bool PlatformInfoLogic::platform_configuration_needed(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    uint16_t flags = 0;
+    bool retVal = false;
+    ae_error_t getflagsError = get_sgx_tcb_evaluation_flags(p_platform_info_blob, &flags);
+    if (AE_SUCCESS == getflagsError) {
+        retVal = (0 != (PLATFORM_CONFIGURATION_NEEDED & flags));
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", retVal, retVal);
+
+    return retVal;
+}
+
 bool PlatformInfoLogic::pse_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob)
 {
     uint16_t flags = 0;
@@ -263,7 +277,8 @@ ae_error_t PlatformInfoLogic::need_epid_provisioning(const platform_info_blob_wr
     if (sgx_gid_out_of_date(p_platform_info_blob) &&
         !qe_svn_out_of_date(p_platform_info_blob) &&
         !cpu_svn_out_of_date(p_platform_info_blob) &&
-        !pce_svn_out_of_date(p_platform_info_blob))
+        !pce_svn_out_of_date(p_platform_info_blob) &&
+        !platform_configuration_needed(p_platform_info_blob))
     {
         status = AESM_NEP_DONT_NEED_UPDATE_PVEQE;      // don't need update, but need epid provisioning
     }

--- a/psw/ae/aesm_service/source/bundles/local_pseop_service_bundle/platform_info_logic.cpp
+++ b/psw/ae/aesm_service/source/bundles/local_pseop_service_bundle/platform_info_logic.cpp
@@ -919,8 +919,8 @@ aesm_error_t PlatformInfoLogic::check_update_status(
         }
         if (qe_svn_out_of_date(&pibw) ||
             pse_svn_out_of_date(&pibw) ||
-            pce_svn_out_of_date(&pibw))
-            //psda_svn_out_of_date(p_platform_info))
+            pce_svn_out_of_date(&pibw) ||
+            platform_configuration_needed(&pibw))
         {
             p_update_info->pswUpdate = 1;
             goto set_update_available;
@@ -1222,7 +1222,8 @@ aesm_error_t PlatformInfoLogic::report_attestation_status(
             status = AESM_UPDATE_AVAILABLE;
         }
         if (qe_svn_out_of_date(&pibw) ||
-            pce_svn_out_of_date(&pibw)
+            pce_svn_out_of_date(&pibw) ||
+            platform_configuration_needed(&pibw)
           ||pse_svn_out_of_date(&pibw))
         {
             p_update_info->pswUpdate = 1;

--- a/psw/ae/aesm_service/source/bundles/local_pseop_service_bundle/platform_info_logic.h
+++ b/psw/ae/aesm_service/source/bundles/local_pseop_service_bundle/platform_info_logic.h
@@ -68,6 +68,7 @@ public:
     static bool cpu_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
     static bool qe_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
     static bool pce_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool platform_configuration_needed(const platform_info_blob_wrapper_t* p_platform_info_blob);
     static bool pse_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
     static bool psda_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
     static bool ps_collectively_not_uptodate(const platform_info_blob_wrapper_t* p_platform_info_blob);

--- a/psw/ae/aesm_service/source/common/platform_info_blob.h
+++ b/psw/ae/aesm_service/source/common/platform_info_blob.h
@@ -57,6 +57,8 @@ const uint8_t QE_EPID_GROUP_OUT_OF_DATE = 0x04;
 const uint16_t QUOTE_CPUSVN_OUT_OF_DATE = 0x0001;
 const uint16_t QUOTE_ISVSVN_QE_OUT_OF_DATE = 0x0002;
 const uint16_t QUOTE_ISVSVN_PCE_OUT_OF_DATE = 0x0004;
+/* the EPID signature of the ISV enclave QUOTE has been verified correctly but additional configuration of SGX platform may be needed.*/
+const uint16_t PLATFORM_CONFIGURATION_NEEDED= 0x0008;
 
 /* Masks for sgx_pse_evaluation_flags
    PS_SEC_PROP_DESC.PSE_ISVSVN is out of date*/


### PR DESCRIPTION
CONFIGURATION_NEEDED Flag is added to Platform Info Blob TLV (version 2). Current implementation is based on version 1.
