### PR TITLE
Guard weak_alias definition with ifndef

### DIFF
--- a/common/inc/internal/util.h
+++ b/common/inc/internal/util.h
@@ -77,6 +77,8 @@
 #include <stddef.h>
 #define container_of(ptr, type, member) (type *)( (char *)(ptr) - offsetof(type,member) )
 
+#ifndef weak_alias
 #define weak_alias(_old, _new) __typeof(_old) _new __attribute__((weak, alias(#_old)))
+#endif
 
 #endif


### PR DESCRIPTION
The musl libc implementation already defines weak_alias and conflicts
with this unguarded define.

Asylo is experimenting with switching to musl from newlib, and this was a small snag.