### PR TITLE
Add missing #include to trts_veh.cpp

### DIFF
--- a/sdk/trts/trts_veh.cpp
+++ b/sdk/trts/trts_veh.cpp
@@ -49,6 +49,7 @@
 #include "util.h"
 #include "trts_util.h"
 #include "trts_shared_constants.h"
+#include "se_cdefs.h"
 
 
 typedef struct _handler_node_t


### PR DESCRIPTION
The ce_cdefs header defines SE_64, which this source file depends on.
When building with clang, this missing header causes the build to break.

Signed-off-by: Dionna Glaze <drdeeglaze@gmail.com>