### PR TITLE
Add trace messages for elf parser failures

### DIFF
--- a/psw/urts/parser/elfparser.cpp
+++ b/psw/urts/parser/elfparser.cpp
@@ -111,28 +111,49 @@ const T* get_section_raw_data(const ElfW(Ehdr) *elf_hdr, ElfW(Addr) start_addr)
 bool validate_elf_header(const ElfW(Ehdr) *elf_hdr)
 {
     // validate magic number
-    if (memcmp(&elf_hdr->e_ident, ELFMAG, SELFMAG))
+    if (memcmp(&elf_hdr->e_ident, ELFMAG, SELFMAG)) {
+        SE_TRACE(SE_TRACE_ERROR, "Incorrect magic number\n");
         return false;
+    }
 
 #if RTS_SYSTEM_WORDSIZE == 64
-    if (ELFCLASS64 != elf_hdr->e_ident[EI_CLASS])
+    if (ELFCLASS64 != elf_hdr->e_ident[EI_CLASS]) {
+        SE_TRACE(SE_TRACE_ERROR, "Expected ELFCLASS64: 0x%x\n",
+                 elf_hdr->e_ident[EI_CLASS]);
         return false;
+    }
 #else
-    if (ELFCLASS32 != elf_hdr->e_ident[EI_CLASS])
+    if (ELFCLASS32 != elf_hdr->e_ident[EI_CLASS]) {
+        SE_TRACE(SE_TRACE_ERROR, "Expected ELFCLASS32: 0x%x\n",
+                 elf_hdr->e_ident[EI_CLASS]);
         return false;
+    }
 #endif
 
-    if (ELFDATA2LSB!= elf_hdr->e_ident[EI_DATA])
+    if (ELFDATA2LSB!= elf_hdr->e_ident[EI_DATA]) {
+        SE_TRACE(SE_TRACE_ERROR, "Expected ELFDATA2LSB: 0x%x\n",
+                 elf_hdr->e_ident[EI_DATA]);
         return false;
+    }
 
-    if (EV_CURRENT != elf_hdr->e_ident[EI_VERSION])
+    if (EV_CURRENT != elf_hdr->e_ident[EI_VERSION]) {
+        SE_TRACE(SE_TRACE_ERROR, "Expected EV_CURRENT: 0x%x\n",
+                 elf_hdr->e_ident[EI_VERSION]);
         return false;
+    }
 
-    if (ET_DYN != elf_hdr->e_type)
+    if (ET_DYN != elf_hdr->e_type) {
+        SE_TRACE(SE_TRACE_ERROR, "Expected ET_DYN: 0x%x\n",
+                 elf_hdr->e_type);
         return false;
+    }
 
-    if (sizeof(ElfW(Phdr)) != elf_hdr->e_phentsize)
+    if (sizeof(ElfW(Phdr)) != elf_hdr->e_phentsize) {
+        SE_TRACE(SE_TRACE_ERROR, "Expected phentsize == %d, got %d\n",
+                 sizeof(ElfW(Phdr)),
+                 elf_hdr->e_phentsize);
         return false;
+    }
 
     return true;
 }
@@ -608,45 +629,60 @@ sgx_status_t ElfParser::run_parser()
     if (m_sections.size() != 0) return SGX_SUCCESS;
 
     const ElfW(Ehdr) *elf_hdr = (const ElfW(Ehdr) *)m_start_addr;
-    if (elf_hdr == NULL || m_len < sizeof(ElfW(Ehdr)))
+    if (elf_hdr == NULL || m_len < sizeof(ElfW(Ehdr))) {
+        SE_TRACE_ERROR("Header invalid size\n");
         return SGX_ERROR_INVALID_ENCLAVE;
-
+    }
     /* Check elf header*/
-    if (!validate_elf_header(elf_hdr))
+    if (!validate_elf_header(elf_hdr)) {
+        SE_TRACE_ERROR("Header invalid\n");
         return SGX_ERROR_INVALID_ENCLAVE;
-
+    }
     /* Get and check machine mode */
-    if (!get_bin_fmt(elf_hdr, m_bin_fmt))
+    if (!get_bin_fmt(elf_hdr, m_bin_fmt)) {
+        SE_TRACE_ERROR("Bin fmt incorrect\n");
         return SGX_ERROR_MODE_INCOMPATIBLE;
+    }
 
     /* Check if there is any overlap segment, and make sure the segment is 1 page aligned;
     * TLS segment must exist.
     */
-    if (!validate_segment(elf_hdr, m_len))
+    if (!validate_segment(elf_hdr, m_len)) {
+        SE_TRACE_ERROR("Segment incorrect\n");
         return SGX_ERROR_INVALID_ENCLAVE;
+    }
 
-    if (!parse_dyn(elf_hdr, &m_dyn_info[0]))
+    if (!parse_dyn(elf_hdr, &m_dyn_info[0])) {
+        SE_TRACE_ERROR("Dyn incorrect\n");
         return SGX_ERROR_INVALID_ENCLAVE;
+    }
 
     /* Check if there is any undefined symbol */
     if (!check_symbol_table(elf_hdr, m_dyn_info, m_sym_table))
     {
+        SE_TRACE_ERROR("Symbol table incorrect\n");
         return SGX_ERROR_UNDEFINED_SYMBOL;
     }
 
     /* Check if there is unexpected relocation type */
-    if (!validate_reltabs(elf_hdr, m_dyn_info))
+    if (!validate_reltabs(elf_hdr, m_dyn_info)) {
+        SE_TRACE_ERROR("Reltabs incorrect\n");
         return SGX_ERROR_INVALID_ENCLAVE;
+    }
 
     /* Check if there is .ctor section */
-    if (has_ctor_section(elf_hdr))
+    if (has_ctor_section(elf_hdr)) {
+        SE_TRACE_ERROR("ctor section incorrect\n");
         return SGX_ERROR_INVALID_ENCLAVE;
+    }
 
     /* build regular sections */
     if (build_regular_sections(m_start_addr, m_sections, m_tls_section, m_metadata_offset, m_metadata_block_size))
         return SGX_SUCCESS;
-    else
+    else {
+        SE_TRACE_ERROR("Regular sections incorrect\n");
         return SGX_ERROR_INVALID_ENCLAVE;
+    }
 }
 
 ElfParser::~ElfParser()

--- a/sdk/sign_tool/SignTool/manage_metadata.cpp
+++ b/sdk/sign_tool/SignTool/manage_metadata.cpp
@@ -514,6 +514,7 @@ bool CMetadata::update_layout_entries()
     if(m_rva == 0)
     {
         se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR);
+        se_trace(SE_TRACE_ERROR, "Sections size is 0\n");
         return false;
     }
 
@@ -616,7 +617,8 @@ bool CMetadata::build_layout_entries()
     layout_t *layout_table = (layout_t *) alloc_buffer_from_metadata(size);
     if(layout_table == NULL)
     {
-        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR); 
+        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR);
+        se_trace(SE_TRACE_ERROR, "Layout table could not be allocated\n");
         return false;
     }
     m_metadata->dirs[DIR_LAYOUT].offset = (uint32_t)PTR_DIFF(layout_table, m_metadata);
@@ -858,7 +860,8 @@ bool CMetadata::build_layout_table()
     // tcs template
     if(false == build_tcs_template(tcs_template))
     {
-        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR); 
+        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR);
+        se_trace(SE_TRACE_ERROR, "Could not build TCS template\n");
         return false;
     }
     return true;
@@ -870,7 +873,8 @@ bool CMetadata::build_patch_entries(std::vector<patch_entry_t> &patches)
     patch_entry_t *patch_table = (patch_entry_t *) alloc_buffer_from_metadata(size);
     if(patch_table == NULL)
     {
-        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR); 
+        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR);
+        se_trace(SE_TRACE_ERROR, "Could not allocate patch table");
         return false;
     }
     m_metadata->dirs[DIR_PATCH].offset = (uint32_t)PTR_DIFF(patch_table, m_metadata);
@@ -901,7 +905,8 @@ bool CMetadata::build_patch_table()
     uint64_t rva = m_parser->get_symbol_rva("g_global_data");
     if(0 == rva)
     {
-        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR); 
+        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR);
+        se_trace(SE_TRACE_ERROR, "Could not find g_global_data\n");
          return false;
     }
 
@@ -915,7 +920,8 @@ bool CMetadata::build_patch_table()
     uint8_t *zero = (uint8_t *)alloc_buffer_from_metadata(0);  // get addr only, size will be determined later
     if(zero == NULL)
     {
-        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR); 
+        se_trace(SE_TRACE_ERROR, INVALID_ENCLAVE_ERROR);
+        se_trace(SE_TRACE_ERROR, "Could not allocate 0 bytes\n");
         return false;
     }
     bin_fmt_t bf = m_parser->get_bin_format();


### PR DESCRIPTION
These messages are useful for toolchain debugging.

I found myself seeing inscrutable errors, so I added these trace messages to help narrow down the cause. There's no reason to not have these, I think.