### PR TITLE
Add missing mkdir -p /var/opt/aesmd to aesmd.service

### DIFF
--- a/psw/ae/aesm_service/config/aesmd_service/aesmd.service
+++ b/psw/ae/aesm_service/config/aesmd_service/aesmd.service
@@ -15,6 +15,7 @@ ExecStartPre=@aesm_folder@/linksgx.sh
 ExecStartPre=/bin/mkdir -p /var/run/aesmd/
 ExecStartPre=/bin/chown -R aesmd:aesmd /var/run/aesmd/
 ExecStartPre=/bin/chmod 0755 /var/run/aesmd/
+ExecStartPre=/bin/mkdir -p /var/opt/aesmd/
 ExecStartPre=/bin/chown -R aesmd:aesmd /var/opt/aesmd/
 ExecStartPre=/bin/chmod 0750 /var/opt/aesmd/
 ExecStart=@aesm_folder@/aesm_service


### PR DESCRIPTION
This directory was added in 2.7, but it isn't mkdir-d in the service file (probably relies on the startup.sh hook)