### PR TITLE
Fix sgx_report_attestation_status() and sgx_check_update_status()

### DIFF
--- a/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/epid_quote_service_bundle.cpp
+++ b/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/epid_quote_service_bundle.cpp
@@ -29,6 +29,7 @@
 #include "service_enclave_mrsigner.hh"
 #include "sgx_ql_quote.h"
 #include "se_sig_rl.h"
+#include "platform_info_logic.h"
 
 using namespace cppmicroservices;
 std::shared_ptr<INetworkService> g_network_service;
@@ -520,6 +521,34 @@ public:
         }
         *att_key_id_num = 2;
         return AESM_SUCCESS;
+    }
+
+    aesm_error_t report_attestation_status(
+        uint8_t* platform_info, uint32_t platform_info_size,
+        uint32_t attestation_status,
+        uint8_t* update_info, uint32_t update_info_size)
+    {
+        AESM_DBG_INFO("LocalPseopServiceImp::report_attestation_status");
+        if (false == initialized)
+            return AESM_SERVICE_UNAVAILABLE;
+        AESMLogicLock lock(_qe_pve_mutex);
+        return  PlatformInfoLogic::report_attestation_status(platform_info,platform_info_size,
+            attestation_status,
+            update_info, update_info_size);
+    }
+
+    aesm_error_t check_update_status(
+        uint8_t* platform_info, uint32_t platform_info_size,
+        uint8_t* update_info, uint32_t update_info_size,
+        uint32_t config, uint32_t* status)
+    {
+        AESM_DBG_INFO("LocalPseopServiceImp::check_update_status");
+        if (false == initialized)
+            return AESM_SERVICE_UNAVAILABLE;
+        AESMLogicLock lock(_qe_pve_mutex);
+        return  PlatformInfoLogic::check_update_status(platform_info,platform_info_size,
+            update_info, update_info_size,
+            config, status);
     }
 };
 

--- a/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/platform_info_facility.cpp
+++ b/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/platform_info_facility.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "platform_info_logic.h"
+#include "byte_order.h"
+#include <assert.h>
+#include "sgx_profile.h"
+
+
+#include "cppmicroservices/BundleContext.h"
+#include <cppmicroservices/GetBundleContext.h>
+using namespace cppmicroservices;
+
+ae_error_t PlatformInfoLogic::get_sgx_epid_group_flags(const platform_info_blob_wrapper_t* p_platform_info_blob, uint8_t* pflags)
+{
+    ae_error_t retval = AE_SUCCESS;
+    if (NULL != pflags && NULL != p_platform_info_blob && p_platform_info_blob->valid_info_blob) {
+        *pflags = p_platform_info_blob->platform_info_blob.sgx_epid_group_flags;
+    }
+    else {
+        retval = AE_INVALID_PARAMETER;
+    }
+    return retval;
+}
+
+ae_error_t PlatformInfoLogic::get_sgx_tcb_evaluation_flags(const platform_info_blob_wrapper_t* p_platform_info_blob, uint16_t* pflags)
+{
+    ae_error_t retval = AE_SUCCESS;
+    if (NULL != pflags && NULL != p_platform_info_blob && p_platform_info_blob->valid_info_blob) {
+        const uint16_t* p = reinterpret_cast<const uint16_t*>(p_platform_info_blob->platform_info_blob.sgx_tcb_evaluation_flags);
+        *pflags = lv_ntohs(*p);
+    }
+    else {
+        retval = AE_INVALID_PARAMETER;
+    }
+    return retval;
+}
+
+bool PlatformInfoLogic::sgx_gid_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    uint8_t flags = 0;
+    bool retVal = false;
+    ae_error_t getflagsError = get_sgx_epid_group_flags(p_platform_info_blob, &flags);
+    if (AE_SUCCESS == getflagsError) {
+        retVal = (0 != (QE_EPID_GROUP_OUT_OF_DATE & flags));
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", retVal, retVal);
+
+    return retVal;
+}
+
+bool PlatformInfoLogic::performance_rekey_available(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    //
+    // return whether platform info blob says PR is available
+    // the group associated with PR that's returned corresponds to the group
+    // that we'll be in **after** executing PR
+    //
+    bool retVal = false;
+    uint8_t flags;
+    ae_error_t getflagsError = get_sgx_epid_group_flags(p_platform_info_blob, &flags);
+    if (AE_SUCCESS == getflagsError) {
+        retVal = static_cast<bool>(flags & PERF_REKEY_FOR_QE_EPID_GROUP_AVAILABLE);
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", retVal, retVal);
+    return retVal;
+}
+bool PlatformInfoLogic::qe_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    uint16_t flags = 0;
+    bool retVal = true;
+    ae_error_t getflagsError = get_sgx_tcb_evaluation_flags(p_platform_info_blob, &flags);
+    if (AE_SUCCESS == getflagsError) {
+        retVal = (0 != (QUOTE_ISVSVN_QE_OUT_OF_DATE & flags));
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", retVal, retVal);
+    return retVal;
+}
+
+bool PlatformInfoLogic::pce_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    uint16_t flags = 0;
+    bool retVal = true;
+    ae_error_t getflagsError = get_sgx_tcb_evaluation_flags(p_platform_info_blob, &flags);
+    if (AE_SUCCESS == getflagsError) {
+        retVal = (0 != (QUOTE_ISVSVN_PCE_OUT_OF_DATE & flags));
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", retVal, retVal);
+    return retVal;
+}
+
+bool PlatformInfoLogic::cpu_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    uint16_t flags = 0;
+    bool retVal = false;
+    ae_error_t getflagsError = get_sgx_tcb_evaluation_flags(p_platform_info_blob, &flags);
+    if (AE_SUCCESS == getflagsError) {
+        retVal = (0 != (QUOTE_CPUSVN_OUT_OF_DATE & flags));
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", retVal, retVal);
+
+    return retVal;
+}
+
+bool PlatformInfoLogic::platform_configuration_needed(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    uint16_t flags = 0;
+    bool retVal = false;
+    ae_error_t getflagsError = get_sgx_tcb_evaluation_flags(p_platform_info_blob, &flags);
+    if (AE_SUCCESS == getflagsError) {
+        retVal = (0 != (PLATFORM_CONFIGURATION_NEEDED & flags));
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", retVal, retVal);
+
+    return retVal;
+}
+
+ae_error_t PlatformInfoLogic::need_epid_provisioning(const platform_info_blob_wrapper_t* p_platform_info_blob)
+{
+    ae_error_t status = AESM_NEP_DONT_NEED_EPID_PROVISIONING;
+    if (sgx_gid_out_of_date(p_platform_info_blob) &&
+        !qe_svn_out_of_date(p_platform_info_blob) &&
+        !cpu_svn_out_of_date(p_platform_info_blob) &&
+        !pce_svn_out_of_date(p_platform_info_blob) &&
+        !platform_configuration_needed(p_platform_info_blob))
+    {
+        status = AESM_NEP_DONT_NEED_UPDATE_PVEQE;      // don't need update, but need epid provisioning
+    }
+    else if (!sgx_gid_out_of_date(p_platform_info_blob) && performance_rekey_available(p_platform_info_blob))
+    {
+        status = AESM_NEP_PERFORMANCE_REKEY;
+    }
+    SGX_DBGPRINT_ONE_STRING_TWO_INTS_CREATE_SESSION(__FUNCTION__" returning ", status, status);
+    return status;
+}
+

--- a/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/platform_info_logic.cpp
+++ b/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/platform_info_logic.cpp
@@ -1,0 +1,482 @@
+/*
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "util.h"
+#include "platform_info_logic.h"
+#include "sgx_quote.h"
+#include "aesm_encode.h"
+#include "epid_quote_service.h"
+#include "pve_logic.h"
+#include "aesm_epid_blob.h"
+#include "le2be_macros.h"
+#include "pibsk_pub.hh"
+#include "sgx_sha256_128.h"
+#include <assert.h>
+#include "sgx_profile.h"
+#include "aesm_long_lived_thread.h"
+
+#include "cppmicroservices/BundleContext.h"
+#include <cppmicroservices/GetBundleContext.h>
+#include "cppmicroservices_util.h"
+using namespace cppmicroservices;
+
+static std::shared_ptr<IEpidQuoteService> g_epid_service;
+
+ae_error_t pib_verify_signature(platform_info_blob_wrapper_t& piBlobWrapper)
+{
+    ae_error_t ae_err = AE_FAILURE;
+    sgx_ecc_state_handle_t ecc_handle = NULL;
+
+    uint8_t result = SGX_EC_INVALID_SIGNATURE;
+
+    const uint32_t data_size = static_cast<uint32_t>(sizeof(piBlobWrapper.platform_info_blob) - sizeof(piBlobWrapper.platform_info_blob.signature));
+
+
+    piBlobWrapper.valid_info_blob = false;
+    do
+    {
+        sgx_ec256_public_t publicKey;
+        sgx_ec256_signature_t signature;
+        sgx_status_t sgx_status;
+
+        //BREAK_IF_TRUE((sizeof(publicKey) != sizeof(s_pib_pub_key_big_endian)), ae_err, AE_FAILURE);
+        //BREAK_IF_TRUE((sizeof(signature) != sizeof(piBlobWrapper.platform_info_blob.signature)), ae_err, AE_FAILURE);
+
+        // convert the public key to little endian
+        if(0!=memcpy_s(&publicKey, sizeof(publicKey), s_pib_pub_key_big_endian, sizeof(s_pib_pub_key_big_endian))){
+            ae_err = AE_FAILURE;
+            break;
+        }
+        SwapEndian_32B(((uint8_t*)&publicKey) +  0);
+        SwapEndian_32B(((uint8_t*)&publicKey) + 32);
+
+        // convert the signature to little endian
+        if(0!=memcpy_s(&signature, sizeof(signature), &piBlobWrapper.platform_info_blob.signature, sizeof(piBlobWrapper.platform_info_blob.signature))){
+            ae_err = AE_FAILURE;
+            break;
+        }
+        SwapEndian_32B(((uint8_t*)&signature) +  0);
+        SwapEndian_32B(((uint8_t*)&signature) + 32);
+
+        sgx_status = sgx_ecc256_open_context(&ecc_handle);
+        BREAK_IF_TRUE((SGX_SUCCESS != sgx_status), ae_err, AE_FAILURE);
+
+        sgx_status = sgx_ecdsa_verify((uint8_t*)&piBlobWrapper.platform_info_blob, data_size, &publicKey, &signature, &result, ecc_handle);
+        BREAK_IF_TRUE((SGX_SUCCESS != sgx_status), ae_err, AE_FAILURE);
+
+        if (SGX_EC_VALID != result)
+        {
+            AESM_LOG_WARN(g_event_string_table[SGX_EVENT_PID_SIGNATURE_FAILURE]);
+            break;
+        }
+
+        piBlobWrapper.valid_info_blob = true;
+
+        ae_err = AE_SUCCESS;
+
+    } while (0);
+    if (ecc_handle != NULL) {
+        sgx_ecc256_close_context(ecc_handle);
+    }
+
+    return ae_err;
+}
+
+// It'll give user flexibility to address the needed/pending EPID or PSE provisioning by input parameter-"config" (bit 1: trigger EPID provisioning, bit 2: trigger PSE provisioning/LTP),
+// And user can always learn "FW/SW update is available" or "EPID provisioning & PSE provisioning/LTP is or was needed/pending" from the output parameter - "update_status" & "update_info", no matter whether attestation succeed or not. 
+// The report_attestation_status will not return any indication of SGX TCB component should be updated if attestation_status input parameter is 0)
+
+#define CHECK_UPDATE_STATUS_NEED_UPDATE		0x1
+#define CHECK_UPDATE_STATUS_EPID_PROV		0x2
+#define CHECK_UPDATE_STATUS_CERT_PROV_LTP	0x4
+#define CHECK_UPDATE_STATUS_CONFIG_ALL		(CHECK_UPDATE_STATUS_EPID_PROV | CHECK_UPDATE_STATUS_CERT_PROV_LTP)
+
+aesm_error_t PlatformInfoLogic::check_update_status(
+    uint8_t* platform_info, uint32_t platform_info_size,
+    uint8_t* update_info, uint32_t update_info_size,
+    uint32_t config, uint32_t* status)
+{
+    AESM_DBG_TRACE("enter fun");
+    if (0 != (config & ~CHECK_UPDATE_STATUS_CONFIG_ALL)) { // any unsupported bits in config input
+        return AESM_CONFIG_UNSUPPORTED;
+    }
+
+    if ((NULL == platform_info && NULL != update_info) // can't determine update status w/o PIB
+        || (NULL == platform_info && 0 == config)) { // nothing to do without platform info
+        return AESM_PARAMETER_ERROR;
+    }
+
+    platform_info_blob_wrapper_t pibw;
+
+    //
+    // presence of platform info is conditional, on whether we're up to date
+    // if we're up to date, no platform info and no need for update info
+    //
+    if (((NULL != platform_info) && (sizeof(pibw.platform_info_blob) > platform_info_size)) || ((NULL != update_info) && (sizeof(sgx_update_info_bit_t) > update_info_size)))
+    {
+        return AESM_PARAMETER_ERROR;
+    }
+
+    aesm_error_t ret_status = AESM_SUCCESS;       // status only tells app to look at updateInfo
+
+    // should be okay for status to be null. if all user wants is to know about updates,
+    // then function should be capable of returning STATUS_UPDATE_AVAILABLE and filling in update_info even if update_status is null.
+    if (NULL != status)
+        *status = 0;
+
+    if (NULL != platform_info) {
+        pibw.valid_info_blob = false;
+        memcpy_s(&pibw.platform_info_blob, sizeof(pibw.platform_info_blob), platform_info, platform_info_size);
+	    
+	    //
+	    // contents of input platform info can get stale, but not by virtue of anything we do
+	    // (the latest/current versions can change)
+	    // therefore, we'll use the same platform info the whole time
+	    //
+	    bool pibSigGood = (AE_SUCCESS == pib_verify_signature(pibw));
+	    //
+	    // invalid pib is an error whenever it's provided
+	    //
+	    if (!pibSigGood) {
+	        AESM_DBG_ERROR("pib verify signature failed");
+	        return AESM_PLATFORM_INFO_BLOB_INVALID_SIG;
+	    }
+
+        auto context = cppmicroservices::GetBundleContext();
+        get_service_wrapper(g_epid_service, context);
+	    if (!g_epid_service) {
+	        AESM_DBG_ERROR("failed to get IEpidquoteService service");
+	        return AESM_SERVICE_UNAVAILABLE;
+	    }
+	    uint32_t x_group_id;
+
+	    if (AESM_SUCCESS != g_epid_service->get_extended_epid_group_id(&x_group_id)) {
+	        AESM_DBG_ERROR("get_extended_epid_group_id failed");
+	        return AESM_UNEXPECTED_ERROR;
+	    }
+	    if (pibw.platform_info_blob.xeid != x_group_id) {
+	        return AESM_UNEXPECTED_ERROR;
+	    }
+	    uint32_t gid_mt_result = g_epid_service->is_gid_matching_result_in_epid_blob(pibw.platform_info_blob.gid);
+	    if (IEpidQuoteService::GIDMT_UNMATCHED == gid_mt_result ||
+	        IEpidQuoteService::GIDMT_UNEXPECTED_ERROR == gid_mt_result) {
+	        return AESM_UNEXPECTED_ERROR;
+	    }
+	    else if (IEpidQuoteService::GIDMT_NOT_AVAILABLE == gid_mt_result) {
+	        return AESM_EPIDBLOB_ERROR;
+	    }
+
+	    ae_error_t nepStatus = need_epid_provisioning(&pibw);
+	    AESM_DBG_TRACE("need_epid_provisioning return (ae%d)", nepStatus);
+	    switch (nepStatus)
+	    {
+	    case AESM_NEP_DONT_NEED_EPID_PROVISIONING:
+	    {
+	        break;
+	    }
+	    case AESM_NEP_DONT_NEED_UPDATE_PVEQE:       // sure thing
+	    {
+	        if (NULL != status) {
+	            *status |= CHECK_UPDATE_STATUS_EPID_PROV; // EPID provisioning is�or was�needed/pending
+	        }
+	        if (0 != (config & CHECK_UPDATE_STATUS_EPID_PROV)) {
+	            bool perfRekey = false;
+	            ret_status = PvEAESMLogic::provision(perfRekey, THREAD_TIMEOUT);
+	            if (AESM_BUSY == ret_status || //thread timeout
+	                AESM_PROXY_SETTING_ASSIST == ret_status || //uae service need to set up proxy info and retry
+	                AESM_UPDATE_AVAILABLE == ret_status || //PSW need be updated
+	                AESM_UNRECOGNIZED_PLATFORM == ret_status || //Platform not recognized by Provisioning backend
+	                AESM_OUT_OF_EPC == ret_status) // out of EPC
+	            {
+	                return ret_status;//We should return to uae serivce directly
+	            }
+	            if (AESM_SUCCESS != ret_status &&
+	                AESM_OUT_OF_MEMORY_ERROR != ret_status &&
+	                AESM_BACKEND_SERVER_BUSY != ret_status &&
+	                AESM_NETWORK_ERROR != ret_status &&
+	                AESM_NETWORK_BUSY_ERROR != ret_status)
+	            {
+	                ret_status = AESM_SGX_PROVISION_FAILED;
+	            }
+	        }
+	        break;
+	    }
+	    case AESM_NEP_PERFORMANCE_REKEY:
+	    {
+	        if (NULL != status) {
+	            *status |= CHECK_UPDATE_STATUS_EPID_PROV; // EPID provisioning is�or was�needed/pending
+	        }
+	        if (0 != (config & CHECK_UPDATE_STATUS_EPID_PROV)) {
+	            bool perfRekey = true;
+	            ret_status = PvEAESMLogic::provision(perfRekey, THREAD_TIMEOUT);
+	            if (AESM_BUSY == ret_status ||//thread timeout
+	                AESM_PROXY_SETTING_ASSIST == ret_status ||//uae service need to set up proxy info and retry
+	                AESM_UPDATE_AVAILABLE == ret_status ||
+	                AESM_UNRECOGNIZED_PLATFORM == ret_status ||
+	                AESM_OUT_OF_EPC == ret_status)
+	            {
+	                return ret_status;//We should return to uae serivce directly
+	            }
+	            if (AESM_SUCCESS != ret_status &&
+	                AESM_OUT_OF_MEMORY_ERROR != ret_status &&
+	                AESM_BACKEND_SERVER_BUSY != ret_status &&
+	                AESM_NETWORK_ERROR != ret_status &&
+	                AESM_NETWORK_BUSY_ERROR != ret_status)
+	            {
+	                ret_status = AESM_SGX_PROVISION_FAILED;
+	            }
+	        }
+	        break;
+	    }
+	    default:
+	    {
+	        ret_status = AESM_UNEXPECTED_ERROR;
+	        break;
+	    }
+	    }
+
+    if (NULL != update_info)
+    {
+        sgx_update_info_bit_t* p_update_info = (sgx_update_info_bit_t*)update_info;
+        memset(p_update_info, 0, sizeof(*p_update_info));
+
+        //
+        // here, we treat values that get reported live - cpusvn, qe.isvsvn, pse.isvsvn - different
+        // than values that come out of ltp blob - psda svn, me gid.
+        // in normal flow, live values reported to IAS will be the same as current values now so
+        // we just look at out-of-date bits corresponding to these values.
+        // the alternative would be to compare current with latest as reported by IAS. this
+        // isn't an option for cpusvn since what we get from IAS is equivalent cpusvn.
+        //
+        // for values that come out of ltp blob, for psda svn, we do compare latest with current; for
+        // me gid, we see if current is different that what was most likely reported to ias; we can't
+        // know for sure what was reported since report_attestation_status can be called anytime.
+        //
+        if (cpu_svn_out_of_date(&pibw))
+        {
+            p_update_info->ucodeUpdate = 1;
+            goto set_update_available;
+        }
+        if (qe_svn_out_of_date(&pibw) ||
+            pce_svn_out_of_date(&pibw) ||
+            platform_configuration_needed(&pibw))
+        {
+            p_update_info->pswUpdate = 1;
+            goto set_update_available;
+        }
+        }
+
+    set_update_available:
+        if (NULL != status) {
+            *status |= CHECK_UPDATE_STATUS_NEED_UPDATE;
+        }
+        ret_status = AESM_UPDATE_AVAILABLE;
+
+        //
+        // IAS will provide latest PSDA SVN value => avoid ambiguity like one above
+        // we may not be able to get current PSDA SVN (and we can know that we didn't get it),
+        // for several reasons (no applet file present, no heci, no jhi)
+        // i don't really want to further complicate this code, but
+        // if we can't get the value in the case here, we should return that
+        // "Intel Platform SW" may need to be re-installed
+        //
+
+        //
+        // what if MEI/HECI, JHI, iCLS isn't present/installed?
+        // none of these are in our TCB, but they are necessary to
+        // get properties of our TCB, when PS being used =>
+        // at least need to document this dependency
+        //
+    }
+    return ret_status;
+}
+
+aesm_error_t PlatformInfoLogic::report_attestation_status(
+    uint8_t* platform_info, uint32_t platform_info_size,
+    uint32_t attestation_status,
+    uint8_t* update_info, uint32_t update_info_size)
+{
+
+    AESM_DBG_TRACE("enter fun");
+    //
+    // we don't do anything without platform info
+    //
+    if (NULL == platform_info) {
+        return AESM_PARAMETER_ERROR;
+    }
+
+    platform_info_blob_wrapper_t pibw;
+
+    //
+    // presence of platform info is conditional, on whether we're up to date
+    // if we're up to date, no platform info and no need for update info
+    //
+    if (((sizeof(pibw.platform_info_blob) > platform_info_size)) || ((NULL != update_info) && (sizeof(sgx_update_info_bit_t) > update_info_size))) {
+        return AESM_PARAMETER_ERROR;
+    }
+
+    pibw.valid_info_blob = false;
+    memcpy_s(&pibw.platform_info_blob, sizeof(pibw.platform_info_blob), platform_info, platform_info_size);
+
+    aesm_error_t status = AESM_SUCCESS;       // status only tells app to look at updateInfo
+
+    //
+    // contents of input platform info can get stale, but not by virtue of anything we do
+    // (the latest/current versions can change)
+    // therefore, we'll use the same platform info the whole time
+    //
+    bool pibSigGood = (AE_SUCCESS == pib_verify_signature(pibw));
+    //
+    // invalid pib is an error whenever it's provided
+    //
+    if (!pibSigGood) {
+        AESM_DBG_ERROR("pib verify signature failed");
+        return AESM_PLATFORM_INFO_BLOB_INVALID_SIG;
+    }
+
+    auto context = cppmicroservices::GetBundleContext();
+    get_service_wrapper(g_epid_service, context);
+    if(!g_epid_service){
+        AESM_DBG_ERROR("failed to get IEpidquoteService service");
+        return AESM_SERVICE_UNAVAILABLE;
+    }
+    uint32_t x_group_id;
+
+    if(AESM_SUCCESS != g_epid_service->get_extended_epid_group_id(&x_group_id)){
+        AESM_DBG_ERROR("get_extended_epid_group_id failed");
+        return AESM_UNEXPECTED_ERROR;
+    }
+    if(pibw.platform_info_blob.xeid != x_group_id){
+        return AESM_UNEXPECTED_ERROR;
+    }
+    uint32_t gid_mt_result = g_epid_service->is_gid_matching_result_in_epid_blob( pibw.platform_info_blob.gid);
+    if(IEpidQuoteService::GIDMT_UNMATCHED == gid_mt_result||
+        IEpidQuoteService::GIDMT_UNEXPECTED_ERROR == gid_mt_result){
+            return AESM_UNEXPECTED_ERROR;
+    }
+    else if (IEpidQuoteService::GIDMT_NOT_AVAILABLE == gid_mt_result) {
+            return AESM_EPIDBLOB_ERROR;
+    }
+
+    ae_error_t nepStatus = need_epid_provisioning(&pibw);
+    AESM_DBG_TRACE("need_epid_provisioning return (ae%d)",nepStatus);
+    switch (nepStatus)
+    {
+    case AESM_NEP_DONT_NEED_EPID_PROVISIONING:
+        {
+            break;
+        }
+    case AESM_NEP_DONT_NEED_UPDATE_PVEQE:       // sure thing
+        {
+            bool perfRekey = false;
+            status = PvEAESMLogic::provision(perfRekey, THREAD_TIMEOUT);
+            if (AESM_BUSY == status || //thread timeout
+                AESM_PROXY_SETTING_ASSIST == status || //uae service need to set up proxy info and retry
+                AESM_UPDATE_AVAILABLE == status || //PSW need be updated
+                AESM_UNRECOGNIZED_PLATFORM == status || //Platform not recognized by Provisioning backend
+                AESM_OUT_OF_EPC == status) // out of EPC
+            {
+                return status;//We should return to uae serivce directly
+            }
+            if (AESM_SUCCESS != status &&
+                AESM_OUT_OF_MEMORY_ERROR != status &&
+                AESM_BACKEND_SERVER_BUSY != status &&
+                AESM_NETWORK_ERROR != status &&
+                AESM_NETWORK_BUSY_ERROR != status)
+            {
+                status = AESM_SGX_PROVISION_FAILED;
+            }
+            break;
+        }
+    case AESM_NEP_PERFORMANCE_REKEY:
+        {
+            if (0 == attestation_status)           // pr only if we succeeded (also we'll never get pr unless gid up-to-date)
+            {
+                bool perfRekey = true;
+                status = PvEAESMLogic::provision(perfRekey, THREAD_TIMEOUT);
+                if (AESM_BUSY == status ||//thread timeout
+                    AESM_PROXY_SETTING_ASSIST == status ||//uae service need to set up proxy info and retry
+                    AESM_UPDATE_AVAILABLE == status ||
+                    AESM_UNRECOGNIZED_PLATFORM == status ||
+                    AESM_OUT_OF_EPC == status)
+                {
+                    return status;//We should return to uae serivce directly
+                }
+                if (AESM_SUCCESS != status &&
+                    AESM_OUT_OF_MEMORY_ERROR != status &&
+                    AESM_BACKEND_SERVER_BUSY != status &&
+                    AESM_NETWORK_ERROR != status &&
+                    AESM_NETWORK_BUSY_ERROR != status)
+                {
+                    status = AESM_SGX_PROVISION_FAILED;
+                }
+            }
+            break;
+        }
+    default:
+        {
+            status = AESM_UNEXPECTED_ERROR;
+            break;
+        }
+    }
+
+    //
+    // don't nag happy app about updates
+    //
+    if ((0 != attestation_status) && (NULL != update_info))
+    {
+        sgx_update_info_bit_t* p_update_info = (sgx_update_info_bit_t*)update_info;
+        memset(p_update_info, 0, sizeof(*p_update_info));
+
+        //
+        // here, we treat values that get reported live - cpusvn, qe.isvsvn,
+        // in normal flow, live values reported to attestation server will be the same as current values now so
+        // we just look at out-of-date bits corresponding to these values.
+        // the alternative would be to compare current with latest as reported by IAS. this
+        // isn't an option for cpusvn since what we get from IAS is equivalent cpusvn.
+        //
+        
+        
+        if (cpu_svn_out_of_date(&pibw))
+        {
+            p_update_info->ucodeUpdate = 1;
+            status = AESM_UPDATE_AVAILABLE;
+        }
+        if (qe_svn_out_of_date(&pibw) ||
+            pce_svn_out_of_date(&pibw) ||
+            platform_configuration_needed(&pibw))
+        {
+            p_update_info->pswUpdate = 1;
+            status = AESM_UPDATE_AVAILABLE;
+        }
+    }
+    return status;
+}

--- a/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/platform_info_logic.h
+++ b/psw/ae/aesm_service/source/bundles/epid_quote_service_bundle/platform_info_logic.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _PLATFORM_INFO_LOGIC_H_
+#define _PLATFORM_INFO_LOGIC_H_
+#include "sgx_urts.h"
+#include "aesm_error.h"
+#include "aeerror.h"
+#include "oal/oal.h"
+#include "platform_info_blob.h"
+
+struct update_pse_thread_func_arg;
+
+/*File to declare PlatformInfoLogic Class which is platform independent*/
+class PlatformInfoLogic{
+public:
+    static aesm_error_t check_update_status(
+        uint8_t* platform_info, uint32_t platform_info_size,
+        uint8_t* update_info, uint32_t update_info_size,
+        uint32_t config, uint32_t* status);
+    static aesm_error_t report_attestation_status(
+        uint8_t* platform_info, uint32_t platform_info_size,
+        uint32_t attestation_status,
+        uint8_t* update_info, uint32_t update_info_size);
+    static ae_error_t need_epid_provisioning(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool sgx_gid_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool sgx_epid_group_revoked(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool cpu_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool qe_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool pce_svn_out_of_date(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool platform_configuration_needed(const platform_info_blob_wrapper_t* p_platform_info_blob);
+    static bool performance_rekey_available(const platform_info_blob_wrapper_t* p_platform_info_blob);
+private:
+    static ae_error_t get_sgx_epid_group_flags(const platform_info_blob_wrapper_t* p_platform_info_blob, uint8_t* flags);
+    static ae_error_t get_sgx_tcb_evaluation_flags(const platform_info_blob_wrapper_t* p_platform_info_blob, uint16_t* flags);
+
+};
+#endif
+

--- a/psw/ae/aesm_service/source/core/AESMLogicWrapper.cpp
+++ b/psw/ae/aesm_service/source/core/AESMLogicWrapper.cpp
@@ -428,7 +428,7 @@ aesm_error_t AESMLogicWrapper::reportAttestationStatus(uint8_t *platform_info, u
 {
     uint8_t *output_update_info = new uint8_t[update_info_size]();
     aesm_error_t result = AESM_SERVICE_UNAVAILABLE;
-    std::shared_ptr<IPseopService> service;
+    std::shared_ptr<IEpidQuoteService> service;
     if (!get_service_wrapper(service, g_fw_ctx))
     {
         delete[] output_update_info;
@@ -457,7 +457,7 @@ aesm_error_t AESMLogicWrapper::checkUpdateStatus(uint8_t* platform_info, uint32_
 
 {
 	aesm_error_t result = AESM_SERVICE_UNAVAILABLE;
-	std::shared_ptr<IPseopService> service;
+	std::shared_ptr<IEpidQuoteService> service;
 	if (!get_service_wrapper(service, g_fw_ctx))
 	{
 		return AESM_SERVICE_UNAVAILABLE;

--- a/psw/ae/aesm_service/source/interfaces/epid_quote_service.h
+++ b/psw/ae/aesm_service/source/interfaces/epid_quote_service.h
@@ -29,6 +29,15 @@ struct IEpidQuoteService : public IQuoteService
     enum {GIDMT_UNMATCHED, GIDMT_NOT_AVAILABLE, GIDMT_MATCHED,GIDMT_UNEXPECTED_ERROR};
     virtual uint32_t is_gid_matching_result_in_epid_blob(
         const GroupId& gid) = 0;
+    virtual aesm_error_t report_attestation_status(
+        uint8_t* platform_info, uint32_t platform_info_size,
+        uint32_t attestation_status,
+        uint8_t* update_info, uint32_t update_info_size) = 0;
+    
+    virtual aesm_error_t check_update_status(
+        uint8_t* platform_info, uint32_t platform_info_size,
+        uint8_t* update_info, uint32_t update_info_size,
+        uint32_t attestation_status, uint32_t* status) = 0;        
 };
 
 #endif /* EPID_QUOTE_SERVICE_EXPORT_H */


### PR DESCRIPTION
Remove the dependency on platform service from epid quote service in aesm_service to fix issue #457.
sgx_report_attestation_status() and sgx_check_update_status() functions are copied to epid_quote_service_bundle from local_pseop_service_bundle.