### PR TITLE
Use ByteSizeLong() instead of deprecated ByteSize()

### DIFF
--- a/psw/ae/aesm_service/source/core/ipc/AECheckUpdateStatusRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AECheckUpdateStatusRequest.cpp
@@ -81,9 +81,9 @@ AEMessage* AECheckUpdateStatusRequest::serialize()
         aesm::message::Request::CheckUpdateStatusRequest* mutableReq = msg.mutable_checkupdatestatusreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AECheckUpdateStatusResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AECheckUpdateStatusResponse.cpp
@@ -89,9 +89,9 @@ AEMessage* AECheckUpdateStatusResponse::serialize()
         aesm::message::Response::CheckUpdateStatusResponse* mutableRes = msg.mutable_checkupdatestatusres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AECloseSessionRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AECloseSessionRequest.cpp
@@ -75,9 +75,9 @@ AEMessage* AECloseSessionRequest::serialize()
         aesm::message::Request::CloseSessionRequest* mutableReq = msg.mutable_closesessionreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AECloseSessionResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AECloseSessionResponse.cpp
@@ -84,9 +84,9 @@ AEMessage* AECloseSessionResponse::serialize()
         aesm::message::Response::CloseSessionResponse* mutableRes = msg.mutable_closesessionres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AECreateSessionRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AECreateSessionRequest.cpp
@@ -76,9 +76,9 @@ AEMessage* AECreateSessionRequest::serialize()
         aesm::message::Request::CreateSessionRequest* mutableReq = msg.mutable_createsessionreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AECreateSessionResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AECreateSessionResponse.cpp
@@ -88,9 +88,9 @@ AEMessage* AECreateSessionResponse::serialize()
         aesm::message::Response::CreateSessionResponse* mutableRes = msg.mutable_createsessionres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEExchangeReportRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEExchangeReportRequest.cpp
@@ -82,9 +82,9 @@ AEMessage* AEExchangeReportRequest::serialize()
         aesm::message::Request::ExchangeReportRequest* mutableReq = msg.mutable_exchangereportreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEExchangeReportResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEExchangeReportResponse.cpp
@@ -87,9 +87,9 @@ AEMessage* AEExchangeReportResponse::serialize()
         aesm::message::Response::ExchangeReportResponse* mutableRes = msg.mutable_exchangereportres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetLaunchTokenRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetLaunchTokenRequest.cpp
@@ -82,9 +82,9 @@ AEMessage* AEGetLaunchTokenRequest::serialize()
         aesm::message::Request::GetLaunchTokenRequest* mutableReq = msg.mutable_getlictokenreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetLaunchTokenResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetLaunchTokenResponse.cpp
@@ -77,9 +77,9 @@ AEMessage* AEGetLaunchTokenResponse::serialize()
         aesm::message::Response::GetLaunchTokenResponse* mutableRes = msg.mutable_getlictokenres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetPsCapRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetPsCapRequest.cpp
@@ -73,9 +73,9 @@ AEMessage* AEGetPsCapRequest::serialize(){
         aesm::message::Request::GetPsCapRequest* mutableReq = msg.mutable_getpscapreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetPsCapResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetPsCapResponse.cpp
@@ -87,9 +87,9 @@ AEMessage* AEGetPsCapResponse::serialize()
         aesm::message::Response::GetPsCapResponse* mutableRes = msg.mutable_getpscapres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetQuoteExRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetQuoteExRequest.cpp
@@ -84,9 +84,9 @@ AEMessage* AEGetQuoteExRequest::serialize()
         aesm::message::Request::GetQuoteExRequest* mutableReq = msg.mutable_getquoteexreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetQuoteExResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetQuoteExResponse.cpp
@@ -91,9 +91,9 @@ AEMessage* AEGetQuoteExResponse::serialize()
         aesm::message::Response::GetQuoteExResponse* mutableResp = msg.mutable_getquoteexres();
         mutableResp->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetQuoteRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetQuoteRequest.cpp
@@ -91,9 +91,9 @@ AEMessage* AEGetQuoteRequest::serialize()
         aesm::message::Request::GetQuoteRequest* mutableReq = msg.mutable_getquotereq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetQuoteResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetQuoteResponse.cpp
@@ -91,9 +91,9 @@ AEMessage* AEGetQuoteResponse::serialize()
         aesm::message::Response::GetQuoteResponse* mutableResp = msg.mutable_getquoteres();
         mutableResp->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetQuoteSizeExRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetQuoteSizeExRequest.cpp
@@ -73,9 +73,9 @@ AEMessage* AEGetQuoteSizeExRequest::serialize(){
         aesm::message::Request::GetQuoteSizeExRequest* mutableReq = msg.mutable_getquotesizeexreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetQuoteSizeExResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetQuoteSizeExResponse.cpp
@@ -88,9 +88,9 @@ AEMessage* AEGetQuoteSizeExResponse::serialize()
         aesm::message::Response::GetQuoteSizeExResponse* mutableResp = msg.mutable_getquotesizeexres();
         mutableResp->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListRequest.cpp
@@ -76,9 +76,9 @@ AEMessage* AEGetWhiteListRequest::serialize()
         aesm::message::Request::GetWhiteListRequest* mutableReq = msg.mutable_getwhitelistreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListResponse.cpp
@@ -86,9 +86,9 @@ AEMessage* AEGetWhiteListResponse::serialize()
         aesm::message::Response::GetWhiteListResponse* mutableResp = msg.mutable_getwhitelistres();
         mutableResp->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListSizeRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListSizeRequest.cpp
@@ -71,9 +71,9 @@ AEMessage* AEGetWhiteListSizeRequest::serialize(){
         aesm::message::Request::GetWhiteListSizeRequest* mutableReq = msg.mutable_getwhitelistsizereq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListSizeResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEGetWhiteListSizeResponse.cpp
@@ -88,9 +88,9 @@ AEMessage* AEGetWhiteListSizeResponse::serialize()
         aesm::message::Response::GetWhiteListSizeResponse* mutableResp = msg.mutable_getwhitelistsizeres();
         mutableResp->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEInitQuoteExRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEInitQuoteExRequest.cpp
@@ -81,9 +81,9 @@ AEMessage* AEInitQuoteExRequest::serialize()
         aesm::message::Request::InitQuoteExRequest* mutableReq = msg.mutable_initquoteexreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEInitQuoteExResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEInitQuoteExResponse.cpp
@@ -93,9 +93,9 @@ AEMessage* AEInitQuoteExResponse::serialize()
         aesm::message::Response::InitQuoteExResponse* mutableRes = msg.mutable_initquoteexres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEInitQuoteRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEInitQuoteRequest.cpp
@@ -74,9 +74,9 @@ AEMessage* AEInitQuoteRequest::serialize()
         aesm::message::Request::InitQuoteRequest* mutableReq = msg.mutable_initquotereq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEInitQuoteResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEInitQuoteResponse.cpp
@@ -91,9 +91,9 @@ AEMessage* AEInitQuoteResponse::serialize()
         aesm::message::Response::InitQuoteResponse* mutableRes = msg.mutable_initquoteres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEInvokeServiceRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEInvokeServiceRequest.cpp
@@ -77,9 +77,9 @@ AEMessage* AEInvokeServiceRequest::serialize()
         aesm::message::Request::InvokeServiceRequest* mutableReq = msg.mutable_invokeservicereq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEInvokeServiceResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEInvokeServiceResponse.cpp
@@ -87,9 +87,9 @@ AEMessage* AEInvokeServiceResponse::serialize()
         aesm::message::Response::InvokeServiceResponse* mutableRes = msg.mutable_invokeserviceres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEReportAttestationRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEReportAttestationRequest.cpp
@@ -81,9 +81,9 @@ AEMessage* AEReportAttestationRequest::serialize()
         aesm::message::Request::ReportAttestationErrorRequest* mutableReq = msg.mutable_reporterrreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AEReportAttestationResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEReportAttestationResponse.cpp
@@ -87,9 +87,9 @@ AEMessage* AEReportAttestationResponse::serialize()
         aesm::message::Response::ReportAttestationErrorResponse* mutableRes = msg.mutable_reporterrres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESGXGetExtendedEpidGroupIdRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESGXGetExtendedEpidGroupIdRequest.cpp
@@ -74,9 +74,9 @@ AEMessage* AESGXGetExtendedEpidGroupIdRequest::serialize()
         aesm::message::Request::SGXGetExtendedEpidGroupIdRequest* mutableReq = msg.mutable_sgxgetextendedepidgroupidreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESGXGetExtendedEpidGroupIdResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESGXGetExtendedEpidGroupIdResponse.cpp
@@ -86,9 +86,9 @@ AEMessage* AESGXGetExtendedEpidGroupIdResponse::serialize()
         aesm::message::Response::SGXGetExtendedEpidGroupIdResponse* mutableRes = msg.mutable_sgxgetextendedepidgroupidres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESGXRegisterRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESGXRegisterRequest.cpp
@@ -77,9 +77,9 @@ AEMessage* AESGXRegisterRequest::serialize()
         aesm::message::Request::SGXRegisterRequest* mutableReq = msg.mutable_sgxregisterreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESGXRegisterResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESGXRegisterResponse.cpp
@@ -85,9 +85,9 @@ AEMessage* AESGXRegisterResponse::serialize()
         aesm::message::Response::SGXRegisterResponse* mutableRes = msg.mutable_sgxregisterres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESGXSwitchExtendedEpidGroupRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESGXSwitchExtendedEpidGroupRequest.cpp
@@ -76,9 +76,9 @@ AEMessage* AESGXSwitchExtendedEpidGroupRequest::serialize()
         aesm::message::Request::SGXSwitchExtendedEpidGroupRequest* mutableReq = msg.mutable_sgxswitchextendedepidgroupreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESGXSwitchExtendedEpidGroupResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESGXSwitchExtendedEpidGroupResponse.cpp
@@ -85,9 +85,9 @@ AEMessage* AESGXSwitchExtendedEpidGroupResponse::serialize()
         aesm::message::Response::SGXSwitchExtendedEpidGroupResponse* mutableRes = msg.mutable_sgxswitchextendedepidgroupres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX) {
+        if (msg.ByteSizeLong() <= INT_MAX) {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESelectAttKeyIDRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESelectAttKeyIDRequest.cpp
@@ -71,10 +71,10 @@ AEMessage *AESelectAttKeyIDRequest::serialize()
         aesm::message::Request::SelectAttKeyIDRequest *mutableReq = msg.mutable_selectattkeyidreq();
         mutableReq->CopyFrom(*m_request);
 
-        if (msg.ByteSize() <= INT_MAX)
+        if (msg.ByteSizeLong() <= INT_MAX)
         {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }

--- a/psw/ae/aesm_service/source/core/ipc/AESelectAttKeyIDResponse.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AESelectAttKeyIDResponse.cpp
@@ -82,10 +82,10 @@ AEMessage *AESelectAttKeyIDResponse::serialize()
         aesm::message::Response::SelectAttKeyIDResponse *mutableRes = msg.mutable_selectattkeyidres();
         mutableRes->CopyFrom(*m_response);
 
-        if (msg.ByteSize() <= INT_MAX)
+        if (msg.ByteSizeLong() <= INT_MAX)
         {
             ae_msg = new AEMessage;
-            ae_msg->size = (unsigned int)msg.ByteSize();
+            ae_msg->size = (unsigned int)msg.ByteSizeLong();
             ae_msg->data = new char[ae_msg->size];
             msg.SerializeToArray(ae_msg->data, ae_msg->size);
         }


### PR DESCRIPTION
Since protobuf 3.11.0, deprecated codes are annotated and warned.
https://github.com/protocolbuffers/protobuf/pull/6612

"make psw" fails because of uses of deprecated method ByteSize().
This PR simply replaces all calls to ByteSize() with ByteSizeLong().