### PR TITLE
Docker pr

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+linux/installer/docker
+linux/installer/docker/*
+docker
+docker/*
+docker/util/*
+*.md
+.git*

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Documentation
 - [Intel(R) SGX for Linux\* OS](https://01.org/intel-softwareguard-extensions) project home page on [01.org](https://01.org)
 - [Intel(R) SGX Programming Reference](https://software.intel.com/sites/default/files/managed/7c/f1/332831-sdm-vol-3d.pdf)
 
+Quick Start
+-----------------------------------------
+### Use docker and docker composer
+```
+$ cd docker && ./build_compose_run.sh
+```
+See this [README](docker/README.md) for details.
+
+### On Ubuntu 18.04
+```
+$ cd  build-scripts && ./build_ubuntu.sh
+```
+The easiest way to build SDK, PSW, and run a sample.
 Build and Install the Intel(R) SGX Driver
 -----------------------------------------
 Follow the instructions in the [linux-sgx-driver](https://github.com/01org/linux-sgx-driver) project to build and install the Intel(R) SGX driver.

--- a/build-scripts/build_ubuntu.sh
+++ b/build-scripts/build_ubuntu.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+apt-get update --fix-missing
+apt-get install -y build-essential ocaml ocamlbuild automake autoconf libtool wget \
+	python libssl-dev  git libcurl4-openssl-dev protobuf-compiler libprotobuf-dev \
+       	debhelper cmake lsb-release
+
+cd ../
+./download_prebuilt.sh
+make sdk_install_pkg psw_install_pkg
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,82 @@
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+FROM ubuntu:18.04 as builder
+
+RUN apt-get update --fix-missing
+RUN apt-get install -y build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev 
+RUN apt-get install -y git libcurl4-openssl-dev protobuf-compiler libprotobuf-dev debhelper cmake lsb-release
+
+# We assume this docker file is invoked with root at the top of linux-sgx repo, see shell scripts for example.
+WORKDIR /linux-sgx
+COPY . .
+
+RUN ./download_prebuilt.sh
+
+RUN make sdk_install_pkg
+
+WORKDIR /opt/intel
+RUN sh -c 'echo yes | /linux-sgx/linux/installer/bin/sgx_linux_x64_sdk_*.bin'
+
+WORKDIR /linux-sgx
+RUN make psw_install_pkg
+
+
+FROM ubuntu:18.04 as aesm 
+RUN apt-get update && \ 
+    apt-get install -y libssl1.1 libcurl4 libprotobuf10 module-init-tools make
+ 
+WORKDIR /installer
+COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
+RUN ./sgx_linux_x64_psw*.bin --no-start-aesm
+USER aesmd
+WORKDIR /opt/intel/sgxpsw/aesm/
+ENV LD_LIBRARY_PATH=.
+CMD ./aesm_service --no-daemon
+
+
+FROM ubuntu:18.04 as sample
+RUN apt-get update && \
+    apt-get install -y g++ \
+                       libcurl4-openssl-dev \
+                       libprotobuf-dev \
+                       libssl-dev \
+                       make \
+                       module-init-tools
+WORKDIR /opt/intel
+COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
+RUN ./sgx_linux_x64_psw*.bin --no-start-aesm
+RUN sh -c 'echo yes | ./sgx_linux_x64_sdk_*.bin'
+
+WORKDIR /opt/intel/sgxsdk/SampleCode/SampleEnclave
+RUN SGX_DEBUG=0 SGX_MODE=HW SGX_PRERELEASE=1 make
+
+CMD ./app
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,95 @@
+# Deploy SGX enclaves in containers
+
+Files in this directory demostrate how to deploy SGX enclave applications in docker containers.
+
+These shell scripts demostrate steps to build and start containers for different scenarios
+- [build_and_run_aesm_docker.sh](../docker/build_and_run_aesm_docker.sh) - build and run AESM in docker, using bin installer
+-  [build_and_run_aesm_docker_deb.sh](../docker/build_and_run_aesm_docker_deb.sh) - build and run AESM in docker, using deb installer
+-  [build_and_run_sample_docker.sh](../docker/build_and_run_sample_docker.sh) - build and run SampleEnclave example in docker, using bin installer
+- [build_and_run_ra.sh](../docker/build_and_run_ra.sh) - build and run RemoteAttestation example in docker, using bin installer
+- [build_compose_run.sh](../docker/build_compose_run.sh) - use docker composer to bring up separate containers for AESM and SampleEnclave example.
+
+There are also Kubernates deployment files to demostrate different ways to deploy SGX containers on a minikube node. See [Kubernates deployments](#kubernates-deployments)
+
+## General considerations
+
+### Handling AESM dependency
+
+On CPUs with no flexible launch control support (Kabe Lake, Skylake CPUs), or systems with [SGX out-of-tree driver](https://github.com/intel/linux-sgx-driver), the AESM service is needed to run and host the launch enclave.
+
+Also for applications requiring remote attestation, AESM with a quoting enclave or a quote generation library such as the one provided by [Intel DCAP project](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/QuoteGeneration) is needed to generate quote for the enclave to be attested. In case of quote generation library, it needs be compiled in with the app hosting the attestee enclave. Please refer to [Intel SGX SDK documentation](https://software.intel.com/sgx) for details on remote attestation
+
+It is recommended to either run AESM in separate container or directly on the host and expose the named socket to application containers by mounting the same Socket file on the host filesystem, /tmp/aesmd in this demo.
+
+It is not recommended, but in any case you want to run AESM and application together in the same container, please refer to docker documentation on [multi-service container](https://docs.docker.com/config/containers/multi-service_container/)
+
+### Support for containers in different VMs on the same host
+
+SGX KVM support is not yet available. This means we can only have SGX applications isolated at container (process boundary) level.
+This demo does not show how to deploy SGX app containers into different VMs.  
+
+Another issue to support VMs: to connect to AESM running in separate VM, we need expose its Unix socket as TCP sockt listening for incoming requests.
+
+Potential solution: Use a proxy server container (e.g., socat) on the same VM as AESM to do the listening and forwarding of the requests to the AESM socket. On the application VM, also a proxy client container (e.g., socat) to forward the request to the proxy server. This is demostrated in util/set_up_aesm_socat.sh and util/run_sample_with_socat.sh scripts.
+
+### Scale deployment to multi-host clusters
+
+This demo is designed for single physical node only.
+
+It should be straightforward to scale an SGX application that is stateless: just create more instances of containers on more nodes.
+
+To scale a stateful SGX application, particularly if the enclave it hosts need to access states shared  with its peers, one needs to carefully design a strategy to handle shared states among enclave instances. In addition to address general stateful application scaling issues, the enclaves need to establish trust and protected channels before sharing state between each other. This can become very application specific and is out of scope of this demo.
+
+To handle AESM dependency in mulit-host cluster scenarios, one needs ensure app containers only communicate AESM containers on the same physical machine as quotes and launch token are only valid on the same physical machine. 
+
+Similarly for applications with enclaves doing local attestation, one must bundle those containers (possible in the same k8s pod) to run on the same physical machine.
+
+
+### Handling SGX device node
+
+All SGX applications need access to the SGX device nodes exposed by kernel space driver. Those nodes need be mapped and mounted inside containers.
+
+1. DCAP driver: /dev/sgx
+2. OOT driver: /dev/isgx
+3. Inkernel: /dev/sgx/enclave (for all SGX app containers), /dev/sgx/provision (for apps with enclaves accessing the SGX provisioning keys)
+
+Note docker can pass devices nodes to container from "docker run" command line, but kubernetes requires containers running with "priviledged" mode, which is the approach used in this demo for minikube deployments.
+
+## Build and run docker container directly
+
+### Docker files
+
+Dockerfile is a multi-stage docker file that specifies 3 image build targets:
+1. builder: builds psw and sdk bin installers from source, with necessary prebuilt AEs and libs downloaded from 01.org.
+2. aesm: takes psw installer from builder, install and run the aesm deamon.
+3. sample: takes sdk installer from build, build and run the SampleEnclave app
+
+build_and_run_aesm_docker.sh shows how to build and run the aesm image. This will start an aesm service listening to named socket, mounted to /var/run/aesmd in the container from host /tmp/aesmd
+
+build_and_run_sample_docker.sh shows how to build and run the SampleEnclave app inside container with locally built sgx_sample image.
+
+### Docker composer files
+
+docker-compose.yml can be used with docker composer to start both aesm and sample app in separate containers.
+build_compose_run.sh demostrate its usage.
+
+## Kubernates deployments
+
+There are 3 different deployment files and they can be used to test on a minikube node started with "minikube start --vm-driver=none". Note in future when KVM supports SGX, we can remove the option "--vm-driver=none).
+
+1. aesm-deployment.yaml: start aesm container/pod using local docker sgx_aesm image
+2. sample-deploymen.yaml:start sample container/pod using local docker sgx_sample image. Note this deployment will wait for /tmp/aemsd/aesm.socket created by aesm
+3. all-in-one.yaml: start both aesm and sample containers in one pod. 
+
+Please refer to [minikube docs](https://kubernetes.io/docs/tasks/tools/install-minikube/) for installation, startup, managing deployments.
+
+After installing minikube, kubectl following instructions, here are typical steps to deploy pods of aesm and sample app to the minikube.
+```
+$ sudo minikube start --vm-driver=none
+$ sudo minikube dashboard # to start the dashboard, optional, useful to see status of pods, deployments
+$ sudo kubectl apply -f aesm-deployment.yaml
+$ sudo kubectl apply -f sample-deployment.yaml #order does not matter
+```
+To deploy the all-in-one pod, replace the last two commands with:
+```$ sudo kubectl apply -f all-in-one.yaml```
+

--- a/docker/build_and_run_aesm_docker.sh
+++ b/docker/build_and_run_aesm_docker.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build  --target aesm --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ../
+
+# Create a temporary directory on the host that will be mounted
+# into both the AESM and sample containers at /var/run/aesmd so
+# that the AESM socket will be visible to the sample container
+# in the expected location.  It is critical that /tmp/aesmd be
+# world writable as UIDs may be shifted in the container.
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+
+# Replace /dev/isgx to /dev/sgx if DCAP driver is used
+docker run --env http_proxy --env https_proxy --device=/dev/isgx  -v /dev/log:/dev/log -v /tmp/aesmd:/var/run/aesmd -it sgx_aesm

--- a/docker/build_and_run_sample_docker.sh
+++ b/docker/build_and_run_sample_docker.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target sample --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../
+
+# Expecting aesm and its socket are available from another container
+# Replace /dev/isgx with /dev/sgx for use with DCAP driver
+docker run --env http_proxy --env https_proxy --device=/dev/isgx -v /tmp/aesmd:/var/run/aesmd -it sgx_sample

--- a/docker/build_compose_run.sh
+++ b/docker/build_compose_run.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Create a temporary directory on the host that will be mounted
+# into both the AESM and sample containers at /var/run/aesmd so
+# that the AESM socket will be visible to the sample container
+# in the expected location.  It is critical that /tmp/aesmd be
+# world writable as UIDs may be shifted in the container.
+set -e
+docker build  --target aesm --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ../
+
+docker build --target sample --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../
+
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+docker-compose --verbose up

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Replace /dev/isgx with /dev/sgx if you use the DCAP driver
+#
+version: '3'
+
+services:
+  aesm:
+    image: sgx_aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+
+  sample:
+    image: sgx_sample
+    depends_on:
+      - aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+

--- a/linux/installer/docker/Dockerfile
+++ b/linux/installer/docker/Dockerfile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+FROM ubuntu:18.04 as sgxbase
+RUN apt-get update --fix-missing
+RUN apt-get install -y wget gnupg
+RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' > /etc/apt/sources.list.d/intel-sgx.list
+RUN wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+RUN apt-get update 
+
+FROM sgxbase as sample
+# App build time dependencies
+RUN apt-get install -y build-essential python libssl-dev libcurl4-openssl-dev libprotobuf-dev
+# No aesm, only AESM client side API support for launch. 
+# For applications requiring attestation, add libsgx-quote-ex
+RUN apt-get install -y --no-install-recommends libsgx-launch libsgx-urts
+
+WORKDIR /opt/intel
+RUN wget https://download.01.org/intel-sgx/sgx-linux/2.8/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.8.100.3.bin
+RUN chmod +x sgx_linux_x64_sdk_2.8.100.3.bin
+RUN echo 'yes' | ./sgx_linux_x64_sdk_2.8.100.3.bin
+WORKDIR /opt/intel/sgxsdk/SampleCode/SampleEnclave
+RUN SGX_DEBUG=0 SGX_MODE=HW SGX_PRERELEASE=1 make
+CMD ./app
+
+
+FROM sgxbase as aesm 
+RUN  apt-get install -y libssl1.1 libcurl4 libprotobuf10 module-init-tools make
+RUN apt-get install -y libsgx-aesm-launch-plugin
+
+ 
+USER aesmd
+WORKDIR /opt/intel/sgx-aesm-service/aesm
+ENV LD_LIBRARY_PATH=.
+CMD ./aesm_service --no-daemon
+

--- a/linux/installer/docker/README.md
+++ b/linux/installer/docker/README.md
@@ -1,0 +1,51 @@
+# Deploy SGX enclaves in containers
+
+Files in this directory demostrate how to deploy SGX enclave applications in docker containers.
+
+## Quick Start
+
+###  Prerequisites
+1. Install [docker and composer](https://docs.docker.com/) and configure them properly following respective installation guide.
+2. Install [SGX out-of-tree driver](https://github.com/intel/linux-sgx-driver). **Note**: See below to run with DCAP driver or SGX capable kernel.
+
+### Run with docker composer
+This will start aesm and sample from one terminal using docker composer.
+```
+$ ./build_compose_run.sh
+```
+
+### Run with docker directly
+
+Alternative you can run aesm and sample containers in two separate terminals. 
+
+In first terminal, 
+```
+$ ./build_and_run_aesm_docker.sh
+```
+In second terminal, 
+```
+$ ./build_and_run_sample_docker.sh
+```
+
+
+## Shell scripts
+The shell scripts demostrate steps to build and start containers for different scenarios.
+- [build_and_run_aesm_docker.sh](../docker/build_and_run_aesm_docker.sh) - build and run AESM in docker, using bin installer
+- [build_and_run_sample_docker.sh](../docker/build_and_run_sample_docker.sh) - build and run SampleEnclave example in docker, using bin installer
+- [build_compose_run.sh](../docker/build_compose_run.sh) - use docker composer to bring up separate containers for AESM and SampleEnclave example.
+
+## The Dockerfile
+
+The [Dockerfile](../docker/Dockerfile) is a multi-stage docker file that specifies 3 image build targets:
+1. sgxbase: use ubuntu 18.04 base, add SGX PPA repo hosted on 01.org to package manager source list.
+2. aesm: Install sgx-aesm and its dependencies from the SGX PPA, start AESM as service.
+3. sample: Install SGX sdk and runtime libaries, build and run the SampleEnclave app in SDK sample code.
+
+## DCAP driver and kernel with SGX patches
+
+[SGX kernel patches](https://github.com/jsakkine-intel/linux-sgx/commits/master) are still in process of upstreaming.
+The [DCAP driver](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver) is developed to imitate the kernel patches as closely as possible. To use custom built kernel with SGX patches or the DCAP driver instead of the SGX2 driver mentioned above, you need following modifications:
+1. Replace "/dev/isgx" device with "/dev/sgx/enclave" and "/dev/sgx/provision" devices for aesm in docker-compose.yml  and build_and_run_aesm_docker.sh
+2. Replace "/dev/isgx" with "/dev/sgx/enclave" for sample container in docker-compose.yml and build_and_run_sample_docker.sh 
+
+**Note**: When you switch between DCAP driver, SGX2 driver, make sure you un-install previous driver and reset the OS before installing the other one.

--- a/linux/installer/docker/build_and_run_aesm_docker.sh
+++ b/linux/installer/docker/build_and_run_aesm_docker.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build  --target aesm --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ../
+
+# Create a temporary directory on the host that will be mounted
+# into both the AESM and sample containers at /var/run/aesmd so
+# that the AESM socket will be visible to the sample container
+# in the expected location.  It is critical that /tmp/aesmd be
+# world writable as UIDs may be shifted in the container.
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+
+# Replace /dev/isgx to /dev/sgx if DCAP driver is used
+docker run --env http_proxy --env https_proxy --device=/dev/isgx  -v /dev/log:/dev/log -v /tmp/aesmd:/var/run/aesmd -it sgx_aesm

--- a/linux/installer/docker/build_and_run_sample_docker.sh
+++ b/linux/installer/docker/build_and_run_sample_docker.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target sample --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../
+
+# Expecting aesm and its socket are available from another container
+# Replace /dev/isgx with /dev/sgx for use with DCAP driver
+docker run --env http_proxy --env https_proxy --device=/dev/isgx -v /tmp/aesmd:/var/run/aesmd -it sgx_sample

--- a/linux/installer/docker/build_compose_run.shx
+++ b/linux/installer/docker/build_compose_run.shx
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Create a temporary directory on the host that will be mounted
+# into both the AESM and sample containers at /var/run/aesmd so
+# that the AESM socket will be visible to the sample container
+# in the expected location.  It is critical that /tmp/aesmd be
+# world writable as UIDs may be shifted in the container.
+set -e
+docker build  --target aesm --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ../
+
+docker build --target sample --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../
+
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+docker-compose --verbose up

--- a/linux/installer/docker/docker-compose.yml
+++ b/linux/installer/docker/docker-compose.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Replace /dev/isgx with /dev/sgx if you use the DCAP driver
+#
+version: '3'
+
+services:
+  aesm:
+    image: sgx_aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+
+  sample:
+    image: sgx_sample
+    depends_on:
+      - aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+


### PR DESCRIPTION
Add docker and composer support to build, run sample app in container.
Files in linux/installer/docker use latest release on 01.org
Files in docker/ build psw, sdk from this repo, then install and run aesm, sample app
Updated README to document quick start scripts for docker and ubuntu 18.04 environments.