### PR TITLE
Add docker files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+linux/installer/docker
+linux/installer/docker/*
+docker
+docker/*
+docker/util/*
+*.md
+.git*
+*/*/.git*

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Documentation
 - [Intel(R) SGX for Linux\* OS](https://01.org/intel-softwareguard-extensions) project home page on [01.org](https://01.org)
 - [Intel(R) SGX Programming Reference](https://software.intel.com/sites/default/files/managed/7c/f1/332831-sdm-vol-3d.pdf)
 
+Quick Start
+-----------------------------------------
+### Use Docker and Docker Compose
+```
+$ cd docker/build && ./build_compose_run.sh
+```
+See this [README](docker/build/README.md) for details.
+
 Build and Install the Intel(R) SGX Driver
 -----------------------------------------
 Follow the instructions in the [linux-sgx-driver](https://github.com/01org/linux-sgx-driver) project to build and install the Intel(R) SGX driver.

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -98,5 +98,8 @@ RUN sh -c 'echo yes | ./sgx_linux_x64_sdk_*.bin'
 WORKDIR /opt/intel/sgxsdk/SampleCode/SampleEnclave
 RUN SGX_DEBUG=0 SGX_MODE=HW SGX_PRERELEASE=1 make
 
+RUN adduser -q --disabled-password --gecos "" --no-create-home sgxuser
+USER sgxuser
+
 CMD ./app
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,0 +1,102 @@
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+FROM ubuntu:18.04 as builder
+
+RUN apt-get update && apt-get install  -y \
+    autoconf \
+    automake \
+    build-essential \
+    cmake \
+    curl \
+    debhelper \
+    git \
+    libcurl4-openssl-dev \
+    libprotobuf-dev \
+    libssl-dev \
+    libtool \
+    lsb-release \
+    ocaml \
+    ocamlbuild \
+    protobuf-compiler \
+    python \
+    wget
+
+# We assume this docker file is invoked with root at the top of linux-sgx repo, see shell scripts for example.
+WORKDIR /linux-sgx
+COPY . .
+
+RUN ./download_prebuilt.sh
+
+RUN make sdk_install_pkg
+
+WORKDIR /opt/intel
+RUN sh -c 'echo yes | /linux-sgx/linux/installer/bin/sgx_linux_x64_sdk_*.bin'
+
+WORKDIR /linux-sgx
+RUN make psw_install_pkg
+
+
+FROM ubuntu:18.04 as aesm 
+RUN apt-get update && apt-get install -y \
+    libcurl4 \
+    libprotobuf10 \
+    libssl1.1 \
+    make \
+    module-init-tools
+ 
+WORKDIR /installer
+COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
+RUN ./sgx_linux_x64_psw*.bin --no-start-aesm
+USER aesmd
+WORKDIR /opt/intel/sgxpsw/aesm/
+ENV LD_LIBRARY_PATH=.
+CMD ./aesm_service --no-daemon
+
+
+FROM ubuntu:18.04 as sample
+RUN apt-get update && apt-get install -y \
+    g++ \
+    libcurl4-openssl-dev \
+    libprotobuf-dev \
+    libssl-dev \
+    make \
+    module-init-tools
+
+WORKDIR /opt/intel
+COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
+RUN ./sgx_linux_x64_psw*.bin --no-start-aesm
+RUN sh -c 'echo yes | ./sgx_linux_x64_sdk_*.bin'
+
+WORKDIR /opt/intel/sgxsdk/SampleCode/SampleEnclave
+RUN SGX_DEBUG=0 SGX_MODE=HW SGX_PRERELEASE=1 make
+
+CMD ./app
+

--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -1,0 +1,52 @@
+# Build and run with Docker
+
+Files in this directory demonstrate how to build and install the SGX SDK and PSW, and run SGX applications in Docker containers.
+
+## Quick Start
+
+###  Prerequisites
+1. Install [Docker and Compose](https://docs.docker.com/) and configure them properly following their respective installation guide.
+2. Install [SGX out-of-tree driver](https://github.com/intel/linux-sgx-driver). **Note**: See below to run with the DCAP driver or an SGX capable kernel.
+
+### Run with Docker Compose
+This will start AESM and an SGX sample on one terminal using docker-compose.
+```
+$ ./build_compose_run.sh
+```
+
+### Run with Docker directly
+
+Alternatively, you can run AESM and SGX sample containers in two separate terminals.
+
+In one terminal,
+```
+$ ./build_and_run_aesm_docker.sh
+```
+In another terminal,
+```
+$ ./build_and_run_sample_docker.sh
+```
+
+## Dockerfile
+
+The Dockerfile specifies 3 image build targets:
+1. builder: Builds PSW and SDK bin installers from source. This requires downloading the prebuilt AEs and optimized libs from 01.org.
+2. aesm: Takes the PSW installer from builder to install and run the AESM deamon.
+3. sample: Installs the SDK installer from builder, then builds and runs the SampleEnclave app
+
+- [build_and_run_aesm_docker.sh](./build_and_run_aesm_docker.sh): Shows how to build and run the AESM image in Docker. This will start the AESM service listening to a named socket, mounted in /var/run/aesmd in the container from the host /tmp/aesmd.
+
+- [build_and_run_sample_docker.sh](./build_and_run_sample_docker.sh): Shows how to build and run the SampleEnclave app inside a Docker container with a locally built SGX sample image.
+
+## DCAP driver and kernel with SGX patches
+
+All SGX applications need access to the SGX device nodes exposed by the kernel space driver. Depending on the driver or kernel you are using, the SGX device nodes may have different names and locations. Therefore, you need to ensure those nodes are mapped and mounted inside the containers properly.
+
+[SGX kernel patches](https://github.com/jsakkine-intel/linux-sgx/commits/master) are still in process of upstreaming.
+The [DCAP driver](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver) is developed to imitate the kernel patches as closely as possible. To use a custom built kernel with SGX patches or the DCAP driver instead of the SGX2 driver mentioned above, you need to make following modifications:
+1. Replace "/dev/isgx" device with "/dev/sgx/enclave" and "/dev/sgx/provision" devices for AESM in docker-compose.yml and build_and_run_aesm_docker.sh
+2. Replace "/dev/isgx" with "/dev/sgx/enclave" for the sample container in docker-compose.yml and build_and_run_sample_docker.sh
+
+**Note**: When you switch between DCAP and SGX2 drivers, make sure you uninstall the previous driver and reset the OS before installing the other one.
+
+**Note**: Earlier versions of the DCAP driver and kernel patches may expose the SGX device as a single node at "/dev/sgx".

--- a/docker/build/build_and_run_aesm_docker.sh
+++ b/docker/build/build_and_run_aesm_docker.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target aesm --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ../../
+
+# Create a temporary directory on the host that is mounted
+# into both the AESM and sample containers at /var/run/aesmd
+# so that the AESM socket is visible to the sample container
+# in the expected location. It is critical that /tmp/aesmd is
+# world writable as the UIDs may shift in the container.
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+
+# If you use the DCAP driver, replace /dev/isgx with /dev/sgx/enclave, and add
+# --device=/dev/sgx/provision
+
+docker run --env http_proxy --env https_proxy --device=/dev/isgx -v /dev/log:/dev/log -v /tmp/aesmd:/var/run/aesmd -it sgx_aesm

--- a/docker/build/build_and_run_sample_docker.sh
+++ b/docker/build/build_and_run_sample_docker.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target sample --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../../
+
+# Another container should expose AESM and its socket
+# Replace /dev/isgx with /dev/sgx/enclave if you use the DCAP driver
+docker run --env http_proxy --env https_proxy --device=/dev/isgx -v /tmp/aesmd:/var/run/aesmd -it sgx_sample

--- a/docker/build/build_compose_run.sh
+++ b/docker/build/build_compose_run.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build  --target aesm --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ../../
+
+docker build --target sample --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../../
+
+# Create a temporary directory on the host that is mounted
+# into both the AESM and sample containers at /var/run/aesmd
+# so that the AESM socket is visible to the sample container
+# in the expected location. It is critical that /tmp/aesmd is
+# world writable as the UIDs may shift in the container.
+
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+docker-compose --verbose up

--- a/docker/build/docker-compose.yml
+++ b/docker/build/docker-compose.yml
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# If you use the DCAP driver, replace /dev/isgx with /dev/sgx/enclave for both
+# sample and aesm, and add /dev/sgx/provision in "devices" list for aesm
+#
+version: '3'
+
+services:
+  aesm:
+    image: sgx_aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+
+  sample:
+    image: sgx_sample
+    depends_on:
+      - aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+

--- a/external/openmp/Makefile
+++ b/external/openmp/Makefile
@@ -66,7 +66,7 @@ endif
 
 $(LIBOMP): $(CHECK_SOURCE)
 ifeq ("$(wildcard $(OMP_DIR)/final/runtime/src/sgx_stub.h)", "")
-	cd openmp_code && git apply ../0001-Enable-OpenMP-in-SGX.patch && cd ..
+	cd openmp_code && patch -p1 <../0001-Enable-OpenMP-in-SGX.patch && cd ..
 endif
 	$(MKDIR) openmp_code/final/build && cd openmp_code/final/build && cmake $(OMP_CONFIG) .. && make 
 

--- a/linux/installer/docker/Dockerfile
+++ b/linux/installer/docker/Dockerfile
@@ -61,6 +61,9 @@ RUN apt-get install -y --no-install-recommends libsgx-launch libsgx-urts
 
 COPY --from=sgx_sample_builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/app .
 COPY --from=sgx_sample_builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/enclave.signed.so .
+
+RUN adduser -q --disabled-password --gecos "" --no-create-home sgxuser
+USER sgxuser
 CMD ./app
 
 FROM sgxbase as aesm 

--- a/linux/installer/docker/Dockerfile
+++ b/linux/installer/docker/Dockerfile
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+FROM ubuntu:18.04 as sgxbase
+RUN apt-get update && apt-get install -y \
+    gnupg \
+    wget
+
+RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' > /etc/apt/sources.list.d/intel-sgx.list
+RUN wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+RUN apt-get update 
+
+FROM sgxbase as sgx_sample_builder
+# App build time dependencies
+RUN apt-get install -y build-essential
+
+WORKDIR /opt/intel
+RUN wget https://download.01.org/intel-sgx/sgx-linux/2.8/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.8.100.3.bin
+RUN chmod +x sgx_linux_x64_sdk_2.8.100.3.bin
+RUN echo 'yes' | ./sgx_linux_x64_sdk_2.8.100.3.bin
+WORKDIR /opt/intel/sgxsdk/SampleCode/SampleEnclave
+RUN SGX_DEBUG=0 SGX_MODE=HW SGX_PRERELEASE=1 make
+
+FROM sgxbase as sample
+RUN apt-get install -y \
+    libcurl4 \
+    libprotobuf10 \
+    libssl1.1
+
+# No AESM daemon, only AESM client side API support for launch.
+# For applications requiring attestation, add libsgx-quote-ex
+RUN apt-get install -y --no-install-recommends libsgx-launch libsgx-urts
+
+COPY --from=sgx_sample_builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/app .
+COPY --from=sgx_sample_builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/enclave.signed.so .
+CMD ./app
+
+FROM sgxbase as aesm 
+RUN apt-get install -y \
+    libcurl4 \
+    libprotobuf10 \
+    libssl1.1 \
+    make \
+    module-init-tools
+
+# More aesm plugins, e.g libsgx-aesm-quote-ex-plugin, are needed if application requires attestation. See installation guide.
+RUN apt-get install -y libsgx-aesm-launch-plugin
+
+USER aesmd
+WORKDIR /opt/intel/sgx-aesm-service/aesm
+ENV LD_LIBRARY_PATH=.
+CMD ./aesm_service --no-daemon
+

--- a/linux/installer/docker/README.md
+++ b/linux/installer/docker/README.md
@@ -1,0 +1,49 @@
+# Deploy SGX enclaves in containers
+
+Files in this directory demonstrate how to build and deploy SGX enclave applications using the Intel(R) SGX SDK and PSW in docker containers.
+
+## Quick Start
+
+###  Prerequisites
+1. Install [Docker and Compose](https://docs.docker.com/) and configure them properly following respective their installation guide.
+2. Install [SGX out-of-tree driver](https://github.com/intel/linux-sgx-driver). **Note**: See below to run with the DCAP driver or an SGX capable kernel.
+
+### Run with Docker Compose
+This will start AESM and an SGX sample on one terminal using docker-compose.
+```
+$ ./build_compose_run.sh
+```
+
+### Run with Docker directly
+
+Alternatively you can run AESM and SGX sample containers in two separate terminals.
+
+In one terminal,
+```
+$ ./build_and_run_aesm_docker.sh
+```
+In another terminal,
+```
+$ ./build_and_run_sample_docker.sh
+```
+
+## Dockerfile
+
+The [Dockerfile](../docker/Dockerfile)  specifies 3 image build targets:
+1. sgxbase: Uses Ubuntu 18.04 base, adds SGX PPA repo hosted on 01.org to the package manager source list.
+2. aesm: Installs sgx-aesm and its dependencies from the SGX PPA and starts the AESM service.
+3. sample: Installs the SGX SDK and runtime libaries, builds and runs the SampleEnclave app in SDK sample code.
+
+## DCAP driver and kernel with SGX patches
+
+All SGX applications need access to the SGX device nodes exposed by kernel space driver. Depending on the driver or kernel you are using, the SGX device nodes may have different names and locations. Therefore, you need ensure those nodes mapped and mounted inside the containers appropriately.
+
+[SGX kernel patches](https://github.com/jsakkine-intel/linux-sgx/commits/master) are still in process of upstreaming.
+The [DCAP driver](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver) is developed to imitate the kernel patches as closely as possible. To use custom built kernel with SGX patches or the DCAP driver instead of the SGX2 driver mentioned above, you need make following modifications:
+1. Replace "/dev/isgx" device with "/dev/sgx/enclave" and "/dev/sgx/provision" devices for AESM in docker-compose.yml  and build_and_run_aesm_docker.sh
+2. Replace "/dev/isgx" with "/dev/sgx/enclave" for the sample container in docker-compose.yml and build_and_run_sample_docker.sh
+
+**Note**: When you switch between the DCAP and SGX2 drivers, make sure you uninstall the previous driver and reset the OS before installing the other one.
+
+**Note**: Earlier versions of the DCAP driver and kernel patches may expose the SGX device as a single node at "/dev/sgx".
+

--- a/linux/installer/docker/build_and_run_aesm_docker.sh
+++ b/linux/installer/docker/build_and_run_aesm_docker.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target aesm --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ./
+
+# Create a temporary directory on the host that is mounted
+# into both the AESM and sample containers at /var/run/aesmd
+# so that the AESM socket is visible to the sample container
+# in the expected location. It is critical that /tmp/aesmd is
+# world writable as the UIDs may shift in the container.
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+
+# If you use the DCAP driver, replace /dev/isgx with /dev/sgx/enclave, and add
+# --device=/dev/sgx/provision
+docker run --env http_proxy --env https_proxy --device=/dev/isgx -v /dev/log:/dev/log -v /tmp/aesmd:/var/run/aesmd -it sgx_aesm

--- a/linux/installer/docker/build_and_run_sample_docker.sh
+++ b/linux/installer/docker/build_and_run_sample_docker.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target sample --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ./
+
+# Another container should expose AESM and its socket
+# Replace /dev/isgx with /dev/sgx/enclave if you use the DCAP driver
+docker run --env http_proxy --env https_proxy --device=/dev/isgx -v /tmp/aesmd:/var/run/aesmd -it sgx_sample

--- a/linux/installer/docker/build_compose_run.sh
+++ b/linux/installer/docker/build_compose_run.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build  --target aesm --build-arg https_proxy=$https_proxy \
+              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ./
+
+docker build --target sample --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ./
+
+# Create a temporary directory on the host that is mounted
+# into both the AESM and sample containers at /var/run/aesmd
+# so that the AESM socket is visible to the sample container
+# in the expected location. It is critical that /tmp/aesmd is
+# world writable as the UIDs may shift in the container.
+
+mkdir -p -m 777 /tmp/aesmd
+chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+docker-compose --verbose up

--- a/linux/installer/docker/docker-compose.yml
+++ b/linux/installer/docker/docker-compose.yml
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2020 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# If you use the DCAP driver, replace /dev/isgx with /dev/sgx/enclave for both
+# sample and aesm, and add /dev/sgx/provision in "devices" list for aesm
+#
+version: '3'
+
+services:
+  aesm:
+    image: sgx_aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+
+  sample:
+    image: sgx_sample
+    depends_on:
+      - aesm
+    devices:
+      - /dev/isgx
+    volumes:
+      - /tmp/aesmd:/var/run/aesmd
+    stdin_open: true
+    tty: true
+    environment:
+      - http_proxy
+      - https_proxy
+


### PR DESCRIPTION
Add docker files and scripts to demonstrate how to:
1. build psw, sdk from source, then install in docker and run sample and aesm in containers.
2. install psw, sdk from releases hosted on 01.org, then run sample and aesm in containers.