### PR TITLE
Fix sgx-gdb throw exceptions on every ocall in Rust-SGX

### DIFF
--- a/sdk/debugger_interface/linux/gdb-sgx-plugin/gdb_sgx_plugin.py
+++ b/sdk/debugger_interface/linux/gdb-sgx-plugin/gdb_sgx_plugin.py
@@ -610,7 +610,7 @@ class UpdateOcallFrame(gdb.Breakpoint):
                 return False
             ret_addr_tuple = struct.unpack_from(ret_addr_of_fmt, ret_addr_str)
 
-            gdb.execute("set language c")
+            gdb.execute("set language c++")
             gdb_cmd = "set *(uintptr_t *)%#x = 0" %(int(ocall_frame))
             gdb.execute(gdb_cmd, False, True)
             gdb_cmd = "set *(uintptr_t *)%#x = %#x" %(int(ocall_frame+(2*SIZE)), xbp)

--- a/sdk/debugger_interface/linux/gdb-sgx-plugin/gdb_sgx_plugin.py
+++ b/sdk/debugger_interface/linux/gdb-sgx-plugin/gdb_sgx_plugin.py
@@ -610,12 +610,14 @@ class UpdateOcallFrame(gdb.Breakpoint):
                 return False
             ret_addr_tuple = struct.unpack_from(ret_addr_of_fmt, ret_addr_str)
 
+            gdb.execute("set language c")
             gdb_cmd = "set *(uintptr_t *)%#x = 0" %(int(ocall_frame))
             gdb.execute(gdb_cmd, False, True)
             gdb_cmd = "set *(uintptr_t *)%#x = %#x" %(int(ocall_frame+(2*SIZE)), xbp)
             gdb.execute(gdb_cmd, False, True)
             gdb_cmd = "set *(uintptr_t *)%#x = %#x" %(int(ocall_frame+(3*SIZE)), ret_addr_tuple[0])
             gdb.execute(gdb_cmd, False, True)
+            gdb.execute("set language auto")
 
         return False
 


### PR DESCRIPTION
In Rust-SGX environment, `sgx-gdb` always throws exception after ocall:
```
Python Exception <class 'gdb.error'> syntax error in expression, near `)0x7fffffffd840 = 0'.:
```

And the debugger stops immediately. At this time, the debugger is working in `Rust` mode instead of `C` mode:

```
gdb-peda$ set *(uintptr_t *)0x7fffffffd6d0 = 0
syntax error in expression, near `)0x7fffffffd6d0 = 0'.
gdb-peda$ set *(u32)0x7fffffffd6d0 = 0
syntax error in expression, near `0x7fffffffd6d0 = 0'.
gdb-peda$ p sizeof(u32)
$4 = 0x4
gdb-peda$ show language
The current source language is "auto; currently rust".
gdb-peda$ set language c
gdb-peda$ set *(uintptr_t *)0x7fffffffd6d0 = 0
gdb-peda$
```

This PR helps set the language to `c` before execution of essential gdb commands, and rolls back to `auto` afterwards. This would benefit lots of developers who are developing SGX enclaves in other languages.