### PR TITLE
Fix break of xsave code in SGX sim

### DIFF
--- a/common/src/linux/xsave_gnu.S
+++ b/common/src/linux/xsave_gnu.S
@@ -69,8 +69,8 @@
     lea     g_xsave_mask_low, %eax
     lea     g_xsave_mask_high, %edx
 #else
-    lea_pic g_xsave_mask_low, %rax
-    lea_pic g_xsave_mask_high, %rdx
+    mov     g_xsave_mask_low@GOTPCREL(%rip), %rax
+    mov     g_xsave_mask_high@GOTPCREL(%rip), %rdx
 #endif
     movl    (%xax), %eax
     movl    (%xdx), %edx
@@ -89,7 +89,7 @@ DECLARE_LOCAL_FUNC restore_xregs
     lea     g_xsave_enabled, %eax
 #else
     mov     %rdi, %rcx
-    lea_pic g_xsave_enabled, %rax
+    mov     g_xsave_enabled@GOTPCREL(%rip), %rax
 #endif
     movl    (%xax), %eax
     cmpl    $0, %eax
@@ -108,7 +108,7 @@ DECLARE_LOCAL_FUNC save_xregs
     lea     g_xsave_enabled, %eax
 #else
     mov     %rdi, %rcx
-    lea_pic g_xsave_enabled, %rax
+    mov     g_xsave_enabled@GOTPCREL(%rip), %rax
 #endif
     fwait
     movl    (%xax), %eax


### PR DESCRIPTION
In the 2.8 release, some instructions were swapped to LEA instead of
MOV. However, the values in question are not used as addresses. This
results in two bugs:
1. The xsave mask address is used instead of the actual xsave mask.
2. The "is xsave enabled" global flag is never properly read, and as
   a result, xsave is enabled on all platforms - even those that do
   not support it. This causes crashes on older (e.g. haswell) CPUs.

Signed-off-by: Seth Moore <sethmo@google.com>