### PR TITLE
Update Makefile for RemoteAttestation

### DIFF
--- a/SampleCode/RemoteAttestation/Makefile
+++ b/SampleCode/RemoteAttestation/Makefile
@@ -103,7 +103,7 @@ else
 endif
 
 App_Cpp_Flags := $(App_C_Flags)
-App_Link_Flags := -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) -L. -lsgx_ukey_exchange -lpthread -lservice_provider -Wl,-rpath=$(CURDIR)/sample_libcrypto -Wl,-rpath=$(CURDIR)
+App_Link_Flags := -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) -L. -lsgx_ukey_exchange -lpthread -lservice_provider -Wl,-rpath=$(CURDIR)/../../sdk/sample_libcrypto -Wl,-rpath=$(CURDIR)
 
 ifneq ($(SGX_MODE), HW)
 	App_Link_Flags += -lsgx_epid_sim -lsgx_quote_ex_sim
@@ -118,11 +118,11 @@ App_Name := app
 ######## Service Provider Settings ########
 
 ServiceProvider_Cpp_Files := service_provider/ecp.cpp service_provider/network_ra.cpp service_provider/service_provider.cpp service_provider/ias_ra.cpp 
-ServiceProvider_Include_Paths := -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/libcxx -Isample_libcrypto
+ServiceProvider_Include_Paths := -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/libcxx -I$(CURDIR)/../../sdk/sample_libcrypto
 
-ServiceProvider_C_Flags := -fPIC -Wno-attributes -I$(SGX_SDK)/include -Isample_libcrypto
+ServiceProvider_C_Flags := -fPIC -Wno-attributes -I$(SGX_SDK)/include -I$(CURDIR)/../../sdk/sample_libcrypto
 ServiceProvider_Cpp_Flags := $(ServiceProvider_C_Flags)
-ServiceProvider_Link_Flags :=  -shared -L$(SGX_LIBRARY_PATH) -lsample_libcrypto -Lsample_libcrypto
+ServiceProvider_Link_Flags :=  -shared -L$(SGX_LIBRARY_PATH) $(CURDIR)/../../sdk/sample_libcrypto/libsample_libcrypto.so
 
 ServiceProvider_Cpp_Objects := $(ServiceProvider_Cpp_Files:.cpp=.o)
 


### PR DESCRIPTION
This updates the Makefile for SampleCode/RemoteAttestation in order to incorporate the current directory structure of the repo. My changes work, but you may want to fix things some other way. At any rate, the current version of your repo for SampleCode/RemoteAttestation does not work with your present directory structure.