### PR TITLE
Autogenerate environment.fish script for SDK

### DIFF
--- a/linux/installer/bin/install-sgx-sdk.bin.tmpl
+++ b/linux/installer/bin/install-sgx-sdk.bin.tmpl
@@ -191,12 +191,33 @@ fi
 EOF
 }
 
+generate_environment_script_fish()
+{
+    cat > ${SGX_PACKAGES_PATH}/${SDK_PKG_NAME}/environment.fish <<EOF
+set -x SGX_SDK ${SGX_PACKAGES_PATH}/${SDK_PKG_NAME}
+set -x PATH \$PATH \$SGX_SDK/$(dirname ${BIN_DIR}) \$SGX_SDK/${BIN_DIR}
+set -x PKG_CONFIG_PATH \$PKG_CONFIG_PATH \$SGX_SDK/pkgconfig
+if test -z "\$LD_LIBRARY_PATH"
+     set -x LD_LIBRARY_PATH \$SGX_SDK/sdk_libs
+else
+     set -x LD_LIBRARY_PATH \$LD_LIBRARY_PATH \$SGX_SDK/sdk_libs
+end
+
+EOF
+}
+
 export_the_simulation
 generate_environment_script
+generate_environment_script_fish
 
 echo """
-Please set the environment variables with below command:
+(bash) Please set the environment variables with below command:
 "
 echo -e "\033[32;49;1msource ${SGX_PACKAGES_PATH}/${SDK_PKG_NAME}/environment\033[39;49;0m"
+
+echo """
+(fish) Please set the environment variables with below command:
+"
+echo -e "\033[32;49;1msource ${SGX_PACKAGES_PATH}/${SDK_PKG_NAME}/environment.fish\033[39;49;0m"
 
 exit 0


### PR DESCRIPTION
This commit tweaks `install-sgx-sdk.bin.tmpl` to auto-generate
a version of the `environment` script for fish-style shells in
addition to bash. The generated script is simply called
`environment.fish`.

Signed-off-by: Jakub Konka <jakub.konka@golem.network>