### PR TITLE
config: aesmd.service support for new device files

### DIFF
--- a/psw/ae/aesm_service/config/aesmd_service/aesmd.service
+++ b/psw/ae/aesm_service/config/aesmd_service/aesmd.service
@@ -24,5 +24,7 @@ RestartSec=15s
 DevicePolicy=closed
 DeviceAllow=/dev/isgx rw
 DeviceAllow=/dev/sgx rw
+DeviceAllow=/dev/sgx/enclave rw
+DeviceAllow=/dev/sgx/provision rw
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The current upstream candidate driver users `/dev/sgx/enclave` and `/dev/sgx/provision` files. Add the device files to aesmd systemd service file so that they can be accessed by the service.
