### PR TITLE
Fix aesmd not starting if /dev is mounted as noexec

### DIFF
--- a/psw/ae/aesm_service/config/aesmd_service/aesmd.service
+++ b/psw/ae/aesm_service/config/aesmd_service/aesmd.service
@@ -10,6 +10,7 @@ Environment=AESM_PATH=@aesm_folder@
 Environment=LD_LIBRARY_PATH=@aesm_folder@
 WorkingDirectory=@aesm_folder@
 PermissionsStartOnly=true
+ExecStartPre=/bin/mount -o remount,exec /dev
 ExecStartPre=@aesm_folder@/linksgx.sh
 ExecStartPre=/bin/mkdir -p /var/run/aesmd/
 ExecStartPre=/bin/chown -R aesmd:aesmd /var/run/aesmd/


### PR DESCRIPTION
See https://lore.kernel.org/linux-sgx/4db41057-910c-b686-0428-474debe382c1@fortanix.com/