### PR TITLE
Fixes buggy replay protection counter in local attestation example.

### DIFF
--- a/SampleCode/LocalAttestation/EnclaveInitiator/EnclaveMessageExchange.cpp
+++ b/SampleCode/LocalAttestation/EnclaveInitiator/EnclaveMessageExchange.cpp
@@ -99,7 +99,7 @@ ATTESTATION_STATUS create_session(dh_session_t *session_info)
     {
             return status;
     }
-    
+
     //Ocall to request for a session with the destination enclave and obtain session id and Message 1 if successful
     status = session_request_ocall(&retstatus, &dh_msg1, &session_id);
     if (status == SGX_SUCCESS)
@@ -189,9 +189,9 @@ ATTESTATION_STATUS send_request_receive_response(dh_session_t *session_info,
     if(!req_message)
         return MALLOC_ERROR;
     memset(req_message, 0, sizeof(secure_message_t)+ inp_buff_len);
-    
+
     const uint32_t data2encrypt_length = (uint32_t)inp_buff_len;
-    
+
     //Set the payload size to data to encrypt length
     req_message->message_aes_gcm_data.payload_size = data2encrypt_length;
 
@@ -205,7 +205,7 @@ ATTESTATION_STATUS send_request_receive_response(dh_session_t *session_info,
     status = sgx_rijndael128GCM_encrypt(&session_info->active.AEK, (uint8_t*)inp_buff, data2encrypt_length,
                 reinterpret_cast<uint8_t *>(&(req_message->message_aes_gcm_data.payload)),
                 reinterpret_cast<uint8_t *>(&(req_message->message_aes_gcm_data.reserved)),
-                sizeof(req_message->message_aes_gcm_data.reserved), plaintext, plaintext_length, 
+                sizeof(req_message->message_aes_gcm_data.reserved), plaintext, plaintext_length,
                 &(req_message->message_aes_gcm_data.payload_tag));
 
     if(SGX_SUCCESS != status)
@@ -213,7 +213,7 @@ ATTESTATION_STATUS send_request_receive_response(dh_session_t *session_info,
         SAFE_FREE(req_message);
         return status;
     }
-    
+
     //Allocate memory for the response payload to be copied
     *out_buff = (char*)malloc(max_out_buff_size);
     if(!*out_buff)
@@ -278,12 +278,12 @@ ATTESTATION_STATUS send_request_receive_response(dh_session_t *session_info,
     memset(decrypted_data, 0, decrypted_data_length);
 
     //Decrypt the response message payload
-    status = sgx_rijndael128GCM_decrypt(&session_info->active.AEK, resp_message->message_aes_gcm_data.payload, 
+    status = sgx_rijndael128GCM_decrypt(&session_info->active.AEK, resp_message->message_aes_gcm_data.payload,
                 decrypted_data_length, decrypted_data,
                 reinterpret_cast<uint8_t *>(&(resp_message->message_aes_gcm_data.reserved)),
-                sizeof(resp_message->message_aes_gcm_data.reserved), &(resp_message->message_aes_gcm_data.payload[plain_text_offset]), plaintext_length, 
+                sizeof(resp_message->message_aes_gcm_data.reserved), &(resp_message->message_aes_gcm_data.payload[plain_text_offset]), plaintext_length,
                 &resp_message->message_aes_gcm_data.payload_tag);
-    
+
     if(SGX_SUCCESS != status)
     {
         SAFE_FREE(req_message);
@@ -293,7 +293,7 @@ ATTESTATION_STATUS send_request_receive_response(dh_session_t *session_info,
     }
 
     // Verify if the nonce obtained in the response is equal to the session nonce + 1 (Prevents replay attacks)
-    if(*(resp_message->message_aes_gcm_data.reserved) != (session_info->active.counter + 1 ))
+    if(*((uint32_t*)resp_message->message_aes_gcm_data.reserved) != (session_info->active.counter + 1 ))
     {
         SAFE_FREE(req_message);
         SAFE_FREE(resp_message);
@@ -318,7 +318,7 @@ ATTESTATION_STATUS close_session(dh_session_t *session_info)
 {
     sgx_status_t status;
     uint32_t retstatus;
-    
+
     if(!session_info)
     {
         return INVALID_PARAMETER_ERROR;

--- a/SampleCode/LocalAttestation/EnclaveResponder/EnclaveMessageExchange.cpp
+++ b/SampleCode/LocalAttestation/EnclaveResponder/EnclaveMessageExchange.cpp
@@ -88,7 +88,7 @@ extern "C" ATTESTATION_STATUS session_request(sgx_dh_msg1_t *dh_msg1,
     {
         return status;
     }
-    
+
     //get a new SessionID
     if ((status = (sgx_status_t)generate_session_id(session_id)) != SUCCESS)
         return status; //no more sessions available
@@ -114,7 +114,7 @@ extern "C" ATTESTATION_STATUS session_request(sgx_dh_msg1_t *dh_msg1,
     memcpy(&session_info.in_progress.dh_session, &sgx_dh_session, sizeof(sgx_dh_session_t));
     //Store the session information under the correspoding source enlave id key
     g_dest_session_info_map.insert(std::pair<uint32_t, dh_session_t>(*session_id, session_info));
-    
+
     return status;
 }
 
@@ -160,10 +160,10 @@ extern "C" ATTESTATION_STATUS exchange_report(sgx_dh_msg2_t *dh_msg2,
 
         dh_msg3->msg3_body.additional_prop_length = 0;
         //Process message 2 from source enclave and obtain message 3
-        sgx_status_t se_ret = sgx_dh_responder_proc_msg2(dh_msg2, 
-                                                       dh_msg3, 
-                                                       &sgx_dh_session, 
-                                                       &dh_aek, 
+        sgx_status_t se_ret = sgx_dh_responder_proc_msg2(dh_msg2,
+                                                       dh_msg3,
+                                                       &sgx_dh_session,
+                                                       &dh_aek,
                                                        &initiator_identity);
         if(SGX_SUCCESS != se_ret)
         {
@@ -263,10 +263,10 @@ extern "C" ATTESTATION_STATUS generate_response(secure_message_t* req_message,
     memset(decrypted_data, 0, decrypted_data_length);
 
     //Decrypt the request message payload from source enclave
-    status = sgx_rijndael128GCM_decrypt(&session_info->active.AEK, req_message->message_aes_gcm_data.payload, 
+    status = sgx_rijndael128GCM_decrypt(&session_info->active.AEK, req_message->message_aes_gcm_data.payload,
                 decrypted_data_length, decrypted_data,
                 reinterpret_cast<uint8_t *>(&(req_message->message_aes_gcm_data.reserved)),
-                sizeof(req_message->message_aes_gcm_data.reserved), &(req_message->message_aes_gcm_data.payload[plain_text_offset]), plaintext_length, 
+                sizeof(req_message->message_aes_gcm_data.reserved), &(req_message->message_aes_gcm_data.payload[plain_text_offset]), plaintext_length,
                 &req_message->message_aes_gcm_data.payload_tag);
 
     if(SGX_SUCCESS != status)
@@ -279,7 +279,7 @@ extern "C" ATTESTATION_STATUS generate_response(secure_message_t* req_message,
     ms = (ms_in_msg_exchange_t *)decrypted_data;
 
     // Verify if the nonce obtained in the request is equal to the session nonce
-    if((uint32_t)*(req_message->message_aes_gcm_data.reserved) != session_info->active.counter || *(req_message->message_aes_gcm_data.reserved) > ((2^32)-2))
+    if(*((uint32_t*)req_message->message_aes_gcm_data.reserved) != session_info->active.counter || *((uint32_t*)req_message->message_aes_gcm_data.reserved) > ((uint32_t)-2))
     {
         SAFE_FREE(decrypted_data);
         return INVALID_PARAMETER_ERROR;
@@ -301,7 +301,7 @@ extern "C" ATTESTATION_STATUS generate_response(secure_message_t* req_message,
         SAFE_FREE(decrypted_data);
         return INVALID_REQUEST_TYPE_ERROR;
     }
-    
+
 
     if(resp_data_length > max_payload_size)
     {
@@ -343,7 +343,7 @@ extern "C" ATTESTATION_STATUS generate_response(secure_message_t* req_message,
     status = sgx_rijndael128GCM_encrypt(&session_info->active.AEK, (uint8_t*)resp_data, data2encrypt_length,
                 reinterpret_cast<uint8_t *>(&(temp_resp_message->message_aes_gcm_data.payload)),
                 reinterpret_cast<uint8_t *>(&(temp_resp_message->message_aes_gcm_data.reserved)),
-                sizeof(temp_resp_message->message_aes_gcm_data.reserved), plaintext, plaintext_length, 
+                sizeof(temp_resp_message->message_aes_gcm_data.reserved), plaintext, plaintext_length,
                 &(temp_resp_message->message_aes_gcm_data.payload_tag));
 
     if(SGX_SUCCESS != status)


### PR DESCRIPTION
This fixes two issues with the replay protection counter in the LocalAttestation example:

1. The maximum value of the counter (uint32_t) was calculated using 2^32 which calculates 2 XOR 32. This limits the number of inter enclave communications to 33.
2. The counter is stored using an uint8_t array. At some points in the code the pointer was dereferenced first and casted to uint32_t afterwards. Because of this only the first byte of the counter was taken into account which limits the number of inter enclave communications to 255.

Signed-off-by: Benedikt Kopf <benedikt.kopf@tum.de>