### PR TITLE
Can't build SGX SDK with the current dockerfile

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -55,7 +55,7 @@ COPY . .
 
 RUN ./download_prebuilt.sh
 
-RUN make sdk_install_pkg
+RUN make sdk_install_pkg_no_mitigation
 
 WORKDIR /opt/intel
 RUN sh -c 'echo yes | /linux-sgx/linux/installer/bin/sgx_linux_x64_sdk_*.bin'


### PR DESCRIPTION
Change the make target to build the SDK with no mitigation to avoid having to install the binutils package that contains the updated assembler.