### PR TITLE
Fix typos in sample comments

### DIFF
--- a/SampleCode/RemoteAttestation/isv_app/isv_app.cpp
+++ b/SampleCode/RemoteAttestation/isv_app/isv_app.cpp
@@ -287,7 +287,7 @@ int main(int argc, char* argv[])
             }
             fprintf(OUTPUT, "\nCall sgx_select_att_key_id success.");
         }
-        // Remote attestation will be initiated the ISV server challenges the ISV
+        // Remote attestation will be initiated if the ISV server challenges the ISV
         // app or if the ISV app detects it doesn't have the credentials
         // (shared secret) from a previous attestation required for secure
         // communication with the server.
@@ -741,4 +741,3 @@ int main(int argc, char* argv[])
     getchar();
     return ret;
 }
-

--- a/SampleCode/RemoteAttestation/isv_enclave/isv_enclave.cpp
+++ b/SampleCode/RemoteAttestation/isv_enclave/isv_enclave.cpp
@@ -43,7 +43,7 @@
 // attestation secure channel binding. The public EC key should be hardcoded in
 // the enclave or delivered in a trustworthy manner. The use of a spoofed public
 // EC key in the remote attestation with secure channel binding session may lead
-// to a security compromise. Every different SP the enlcave communicates to
+// to a security compromise. Every different SP the enclave communicates to
 // must have a unique SP public key. Delivery of the SP public key is
 // determined by the ISV. The TKE SIGMA protocl expects an Elliptical Curve key
 // based on NIST P-256


### PR DESCRIPTION
I found a few typos while digging in the samples :)