### PR TITLE
Support to dynamically link with libsgx_launch.so

### DIFF
--- a/psw/ae/aesm_service/source/bundles/le_launch_service_bundle/le_launch_service_bundle.cpp
+++ b/psw/ae/aesm_service/source/bundles/le_launch_service_bundle/le_launch_service_bundle.cpp
@@ -21,8 +21,6 @@ extern "C" bool is_launch_token_required();
 extern ae_error_t start_white_list_thread(unsigned long timeout=THREAD_TIMEOUT);
 extern ThreadStatus white_list_thread;
 
-extern "C" void init_get_launch_token(const func_get_launch_token_t func);
-
 extern "C" sgx_status_t get_launch_token(const enclave_css_t *signature,
                                          const sgx_attributes_t *attribute,
                                          sgx_launch_token_t *launch_token)
@@ -174,7 +172,6 @@ private:
         auto context = cppmicroservices::GetBundleContext();
         get_service_wrapper(g_network_service, context);
         get_service_wrapper(g_launch_service, context);
-        init_get_launch_token(::get_launch_token);
         start_white_list_thread(0);
         initialized = true;
         AESM_DBG_INFO("le bundle started");

--- a/psw/enclave_common/Makefile
+++ b/psw/enclave_common/Makefile
@@ -51,13 +51,13 @@ INC += -I$(SGX_HEADER_DIR)                \
        -I$(LINUX_PSW_DIR)/urts/linux      \
        -I$(LINUX_PSW_DIR)/enclave_common
 
-LDFLAGS := -lwrapper -ldl
+LDFLAGS := -lwrapper -lsgx_launch
 LDFLAGS += $(COMMON_LDFLAGS) -Wl,--version-script=sgx_enclave_common.lds -Wl,--gc-sections
 
 DIR1 := $(LINUX_PSW_DIR)/enclave_common
 DIR2 := $(LINUX_PSW_DIR)/urts/linux
 
-LIB += -L$(COMMON_DIR)/se_wrapper_psw
+LIB += -L$(COMMON_DIR)/se_wrapper_psw -L$(LINUX_PSW_DIR)/uae_service/linux
 
 OBJ := sgx_enclave_common.o edmm_utility.o
 

--- a/psw/urts/linux/Makefile
+++ b/psw/urts/linux/Makefile
@@ -59,7 +59,7 @@ INTERNAL_LDFLAGS := -lwrapper
 LDFLAGS += $(COMMON_LDFLAGS) -Wl,-Bdynamic -L$(BUILD_DIR) -lsgx_enclave_common -lpthread
 INTERNAL_LDFLAGS += $(COMMON_LDFLAGS) -lpthread
 LDFLAGS += -L$(VTUNE_DIR)/sdk/src/ittnotify -littnotify -ldl
-INTERNAL_LDFLAGS += -L$(VTUNE_DIR)/sdk/src/ittnotify -littnotify -ldl
+INTERNAL_LDFLAGS += -L$(VTUNE_DIR)/sdk/src/ittnotify -littnotify -lsgx_launch
 LDFLAGS += -Wl,--version-script=urts.lds -Wl,--gc-sections
 INTERNAL_LDFLAGS += -Wl,--version-script=urts_internal.lds -Wl,--gc-sections
 
@@ -70,7 +70,8 @@ DIR4 := $(LINUX_PSW_DIR)/urts/parser/linux
 DIR5 := $(LINUX_PSW_DIR)/../common/src/linux
 
 LIB += -L$(COMMON_DIR)/se_wrapper_psw \
-       -L$(SGX_LIB_DIR)
+       -L$(SGX_LIB_DIR) \
+       -L$(LINUX_PSW_DIR)/uae_service/linux
 
 OBJ1 := loader.o          \
         node.o            \

--- a/psw/urts/linux/urts_internal.cpp
+++ b/psw/urts/linux/urts_internal.cpp
@@ -45,14 +45,6 @@
 
 extern sgx_status_t _create_enclave(const bool debug, se_file_handle_t pfile, se_file_t& file, le_prd_css_file_t *prd_css_file, sgx_launch_token_t *launch, int *launch_updated, sgx_enclave_id_t *enclave_id, sgx_misc_attribute_t *misc_attr);
 
-extern func_get_launch_token_t get_launch_token_func;
-
-extern "C" void init_get_launch_token(const func_get_launch_token_t func)
-{
-    get_launch_token_func = func;
-}
-
-
 extern "C" sgx_status_t sgx_create_le(const char* file_name, const char* prd_css_file_name, const int debug, sgx_launch_token_t *launch_token, int *launch_token_updated, sgx_enclave_id_t *enclave_id, sgx_misc_attribute_t *misc_attr, int *production_loaded)
 {
     sgx_status_t ret = SGX_SUCCESS;

--- a/psw/urts/linux/urts_internal.lds
+++ b/psw/urts/linux/urts_internal.lds
@@ -20,7 +20,6 @@
         is_launch_token_required;
         sgx_get_metadata;
         sgx_set_switchless_itf;
-        init_get_launch_token;
     local:
         *;
 };


### PR DESCRIPTION
When loading a sgxsdk-written library with dlopen, the libsgx_launch.so will not be loaded immediately until enclave creation function sgx_create_enclave() is called. Before that,
current process may enter into a container before calling sgx_create_enclave(). If so,
libsgx_launch.so has to exist in container, but this is not always true. The following diagram
shows what happens:

```
dlopen("sgxsdk_based.so", RTLD_NOW) and foo = dlsym("foo")
 |
\|/
unshare()
 |
\|/
(*foo)()
 |
+-> sgx_create_enclave()
    |
    +-> dlopen("libsgx_launch.so")
```

The solution is to implement dynamic link with libsgx_launch.so. So using dlopen() to load
libsgx_launch.so should be dropped.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>