### PR TITLE
docker: use volumes for sharing the aesmd socket.

### DIFF
--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -34,7 +34,7 @@ The Dockerfile specifies 3 image build targets:
 2. aesm: Takes the PSW installer from builder to install and run the AESM daemon.
 3. sample: Installs the SDK installer from builder, then builds and runs the SampleEnclave app
 
-- [build_and_run_aesm_docker.sh](./build_and_run_aesm_docker.sh): Shows how to build and run the AESM image in Docker. This will start the AESM service listening to a named socket, mounted in /var/run/aesmd in the container from the host /tmp/aesmd.
+- [build_and_run_aesm_docker.sh](./build_and_run_aesm_docker.sh): Shows how to build and run the AESM image in Docker. This will start the AESM service listening to a named socket, located in /var/run/aesmd in the container and mounted in Docker volume aesmd-socket.
 
 - [build_and_run_sample_docker.sh](./build_and_run_sample_docker.sh): Shows how to build and run the SampleEnclave app inside a Docker container with a locally built SGX sample image.
 

--- a/docker/build/build_and_run_aesm_docker.sh
+++ b/docker/build/build_and_run_aesm_docker.sh
@@ -33,15 +33,9 @@ set -e
 docker build --target aesm --build-arg https_proxy=$https_proxy \
              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ../../
 
-# Create a temporary directory on the host that is mounted
-# into both the AESM and sample containers at /var/run/aesmd
-# so that the AESM socket is visible to the sample container
-# in the expected location. It is critical that /tmp/aesmd is
-# world writable as the UIDs may shift in the container.
-mkdir -p -m 777 /tmp/aesmd
-chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=rw aesmd-socket
 
 # If you use the Legacy Launch Control driver, replace /dev/sgx/enclave with /dev/isgx, and remove
 # --device=/dev/sgx/provision
 
-docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave --device=/dev/sgx/provision -v /dev/log:/dev/log -v /tmp/aesmd:/var/run/aesmd -it sgx_aesm
+docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave --device=/dev/sgx/provision -v /dev/log:/dev/log -v aesmd-socket:/var/run/aesmd -it sgx_aesm

--- a/docker/build/build_and_run_sample_docker.sh
+++ b/docker/build/build_and_run_sample_docker.sh
@@ -33,6 +33,6 @@ set -e
 docker build --target sample --build-arg https_proxy=$https_proxy \
              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../../
 
-# Another container should expose AESM and its socket
+# Another container should expose AESM and its socket in aesmd-socket volume.
 # Replace /dev/sgx/enclave with /dev/isgx if you use the Legacy Launch Control driver
-docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave -v /tmp/aesmd:/var/run/aesmd -it sgx_sample
+docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave -v aesmd-socket:/var/run/aesmd -it sgx_sample

--- a/docker/build/build_compose_run.sh
+++ b/docker/build/build_compose_run.sh
@@ -36,12 +36,5 @@ docker build  --target aesm --build-arg https_proxy=$https_proxy \
 docker build --target sample --build-arg https_proxy=$https_proxy \
              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ../../
 
-# Create a temporary directory on the host that is mounted
-# into both the AESM and sample containers at /var/run/aesmd
-# so that the AESM socket is visible to the sample container
-# in the expected location. It is critical that /tmp/aesmd is
-# world writable as the UIDs may shift in the container.
-
-mkdir -p -m 777 /tmp/aesmd
-chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=rw aesmd-socket
 docker-compose --verbose up

--- a/docker/build/docker-compose.yml
+++ b/docker/build/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - /dev/sgx/enclave
       - /dev/sgx/provision
     volumes:
-      - /tmp/aesmd:/var/run/aesmd
+      - aesmd-socket:/var/run/aesmd
     stdin_open: true
     tty: true
     environment:
@@ -53,10 +53,12 @@ services:
     devices:
       - /dev/sgx/enclave
     volumes:
-      - /tmp/aesmd:/var/run/aesmd
+      - aesmd-socket:/var/run/aesmd
     stdin_open: true
     tty: true
     environment:
       - http_proxy
       - https_proxy
 
+volumes:
+  aesmd-socket:

--- a/linux/installer/docker/build_and_run_aesm_docker.sh
+++ b/linux/installer/docker/build_and_run_aesm_docker.sh
@@ -33,14 +33,8 @@ set -e
 docker build --target aesm --build-arg https_proxy=$https_proxy \
              --build-arg http_proxy=$http_proxy -t sgx_aesm -f ./Dockerfile ./
 
-# Create a temporary directory on the host that is mounted
-# into both the AESM and sample containers at /var/run/aesmd
-# so that the AESM socket is visible to the sample container
-# in the expected location. It is critical that /tmp/aesmd is
-# world writable as the UIDs may shift in the container.
-mkdir -p -m 777 /tmp/aesmd
-chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
+docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=rw aesmd-socket
 
 # If you use the Legacy Launch Control driver, replace /dev/sgx/enclave with /dev/isgx, and remove
 # --device=/dev/sgx/provision
-docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave --device=/dev/sgx/provision -v /dev/log:/dev/log -v /tmp/aesmd:/var/run/aesmd -it sgx_aesm
+docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave --device=/dev/sgx/provision -v /dev/log:/dev/log -v aesmd-socket:/var/run/aesmd -it sgx_aesm

--- a/linux/installer/docker/build_and_run_sample_docker.sh
+++ b/linux/installer/docker/build_and_run_sample_docker.sh
@@ -33,6 +33,6 @@ set -e
 docker build --target sample --build-arg https_proxy=$https_proxy \
              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ./
 
-# Another container should expose AESM and its socket
+# Another container should expose AESM and its socket in volume aesmd-socket
 # Replace /dev/sgx/enclave with /dev/isgx if you use the Legacy Launch Control driver
-docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave -v /tmp/aesmd:/var/run/aesmd -it sgx_sample
+docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave -v aesmd-socket:/var/run/aesmd -it sgx_sample

--- a/linux/installer/docker/build_compose_run.sh
+++ b/linux/installer/docker/build_compose_run.sh
@@ -36,12 +36,6 @@ docker build  --target aesm --build-arg https_proxy=$https_proxy \
 docker build --target sample --build-arg https_proxy=$https_proxy \
              --build-arg http_proxy=$http_proxy -t sgx_sample -f ./Dockerfile ./
 
-# Create a temporary directory on the host that is mounted
-# into both the AESM and sample containers at /var/run/aesmd
-# so that the AESM socket is visible to the sample container
-# in the expected location. It is critical that /tmp/aesmd is
-# world writable as the UIDs may shift in the container.
+docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=rw aesmd-socket
 
-mkdir -p -m 777 /tmp/aesmd
-chmod -R -f 777 /tmp/aesmd || sudo chmod -R -f 777 /tmp/aesmd || true
 docker-compose --verbose up

--- a/linux/installer/docker/docker-compose.yml
+++ b/linux/installer/docker/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - /dev/sgx/enclave
       - /dev/sgx/provision
     volumes:
-      - /tmp/aesmd:/var/run/aesmd
+      - aesmd-socket:/var/run/aesmd
     stdin_open: true
     tty: true
     environment:
@@ -53,10 +53,12 @@ services:
     devices:
       - /dev/sgx/enclave
     volumes:
-      - /tmp/aesmd:/var/run/aesmd
+      - aesmd-socket:/var/run/aesmd
     stdin_open: true
     tty: true
     environment:
       - http_proxy
       - https_proxy
 
+volumes:
+  aesmd-socket:


### PR DESCRIPTION
When sharing `aesmd` socket between two docker containers, use a dedicated volume instead of temporary directory on the host.