### PR TITLE
Enhance SGX simulation mode to support TLS variables

### DIFF
--- a/sdk/simulation/tinst/t_instructions.cpp
+++ b/sdk/simulation/tinst/t_instructions.cpp
@@ -281,7 +281,26 @@ static void _EREPORT(const sgx_target_info_t* ti, const sgx_report_data_t* rd, s
 }
 
 ////////////////////////////////////////////////////////////////////////
+#define ARCH_SET_GS 0x1001
+#define ARCH_SET_FS 0x1002
 
+static void arch_prctl(int code, unsigned long addr)
+{
+    int ret;
+
+    __asm__("mov %1, %%edi\n\t"
+            "movq %2, %%rsi\n\t"
+            "mov $0x9e,%%eax\n\t"
+            "syscall\n\t"
+            "mov %%eax, %0\n\t"
+            :"=a"(ret)
+            :"r"(code), "r"(addr)
+            :"r11", "rcx");
+    if(ret != 0) {
+        // This should never happen.
+        abort();
+    }
+}
 
 static void
 _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xdi) __attribute__((section(".nipx")));
@@ -303,7 +322,7 @@ _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xd
     GP_ON(tcs == NULL);
 
     // restore the used _tls_array
-    GP_ON(td_mngr_restore_td(tcs) == false);
+    // GP_ON(td_mngr_restore_td(tcs) == false);
 
     // check thread is in use or not
     tcs_sim_t *tcs_sim = reinterpret_cast<tcs_sim_t *>(tcs->reserved);
@@ -315,6 +334,10 @@ _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xd
     regs.xcx = tcs_sim->saved_aep;
     regs.xsi = xsi;
     regs.xdi = xdi;
+
+    //restore the FS, GS base address
+    arch_prctl(ARCH_SET_FS, tcs_sim->saved_fs_base);
+    arch_prctl(ARCH_SET_GS, tcs_sim->saved_gs_base);
 
     load_regs(&regs);
 

--- a/sdk/simulation/trtssim/linux/Makefile
+++ b/sdk/simulation/trtssim/linux/Makefile
@@ -76,8 +76,8 @@ TINST_OBJS   := t_instructions.o \
 
 LOWLIB_OBJS  := lowlib.o
 
-TLS_OBJS     := get_tcs.o \
-                restore_tls.o
+# TLS_OBJS     := get_tcs.o \
+#                 restore_tls.o
 
 TLDR_ASM_OBJS := trts_pic.o \
                 metadata_sec.o \
@@ -101,8 +101,8 @@ vpath %.c   $(TLS_DIR):$(TLDR_DIR)
 all: $(LIBTRTS) | $(BUILD_DIR)
 	$(CP) $< $|
 
-$(LIBTRTS): $(TRTS_OBJS) $(TINST_OBJS) $(LOWLIB_OBJS) $(TLS_OBJS) $(TLDR_OBJS) 
-	$(AR) rcsD $@ $(TRTS_OBJS) $(TINST_OBJS) $(LOWLIB_OBJS) $(TLS_OBJS) $(TLDR_OBJS)
+$(LIBTRTS): $(TRTS_OBJS) $(TINST_OBJS) $(LOWLIB_OBJS) $(TLDR_OBJS) 
+	$(AR) rcsD $@ $(TRTS_OBJS) $(TINST_OBJS) $(LOWLIB_OBJS) $(TLDR_OBJS)
 
 # ------------------------------------------------------------
 $(TRTS1_OBJS):    CPPFLAGS += -I$(COMMON_DIR)/inc/tlibc \
@@ -120,9 +120,9 @@ $(TINST_OBJS):   CPPFLAGS += -I$(SIM_DIR)/assembly/    \
                              -I$(LINUX_SDK_DIR)/selib/ \
                              -O0
 
-$(TLS_OBJS):     CPPFLAGS += -I$(SIM_DIR)/assembly/ \
-                             -I$(SIM_DIR)/assembly/linux \
-                             -I$(SIM_DIR)/uinst/
+# $(TLS_OBJS):     CPPFLAGS += -I$(SIM_DIR)/assembly/ \
+#                              -I$(SIM_DIR)/assembly/linux \
+#                              -I$(SIM_DIR)/uinst/
 
 $(TLDR_C_OBJS):  CPPFLAGS += -I$(COMMON_DIR)/inc/internal/linux/ \
                              -I$(SIM_DIR)/assembly/

--- a/sdk/simulation/uinst/Makefile
+++ b/sdk/simulation/uinst/Makefile
@@ -48,8 +48,8 @@ CPPFLAGS += -I$(COMMON_DIR)/inc/         \
 
 CXXFLAGS += -Werror -fPIC
 
-OBJ1 := linux/set_tls.o \
-        linux/restore_tls.o
+# OBJ1 := linux/set_tls.o \
+#         linux/restore_tls.o
 
 LIBSESIMU_U := libsesimu_u.a
 
@@ -65,11 +65,11 @@ enclave_mngr.o: enclave_mngr.cpp
 u_instructions.o: u_instructions.cpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -O0 -Wno-error=cpp -c $< -o $@
 
-$(LIBSESIMU_U): u_instructions.o enclave_mngr.o $(OBJ1)
+$(LIBSESIMU_U): u_instructions.o enclave_mngr.o #$(OBJ1)
 	$(AR) rcs $@ $^
 
-$(OBJ1):
-	$(MAKE) -C linux
+# $(OBJ1):
+# 	$(MAKE) -C linux
 
 .PHONY: clean
 clean:

--- a/sdk/simulation/uinst/td_mngr.h
+++ b/sdk/simulation/uinst/td_mngr.h
@@ -43,6 +43,8 @@ typedef struct _tcs_sim_t
     size_t    tcs_state;
     uintptr_t saved_dtv;
     uintptr_t saved_fs_gs_0;
+    uintptr_t saved_fs_base;
+    uintptr_t saved_gs_base;
 } tcs_sim_t;
 
 #define TCS_STATE_INACTIVE   0  //The TCS is available for a normal EENTER
@@ -61,10 +63,10 @@ extern "C" {
 #endif
 
 //Add the implementation to get the _tls_array pointer in GNU here.
-#include "gnu_tls.h"
+//#include "gnu_tls.h"
 extern uint8_t __ImageBase;
-int td_mngr_set_td(void *enclave_base, tcs_t *tcs);
-int td_mngr_restore_td(tcs_t *tcs)  __attribute__((section (".nipx")));
+//int td_mngr_set_td(void *enclave_base, tcs_t *tcs);
+//int td_mngr_restore_td(tcs_t *tcs)  __attribute__((section (".nipx")));
 
 #ifdef __cplusplus
 }

--- a/sdk/simulation/uinst/u_instructions.cpp
+++ b/sdk/simulation/uinst/u_instructions.cpp
@@ -36,6 +36,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <asm/prctl.h>
+#include <sys/prctl.h>
+#include <errno.h>
 
 #include "arch.h"
 #include "util.h"
@@ -205,7 +208,7 @@ uintptr_t _EREMOVE(const void *epc_lin_addr)
 }
 
 ////////////////////////////////////////////////////////////////////////
-
+extern "C" int arch_prctl(int code, unsigned long addr);
 // Master entry functions
 
 // The call to load_regs assumes the existence of a frame pointer.
@@ -267,8 +270,12 @@ void _SE3(uintptr_t xax, uintptr_t xbx,
         GP_ON_EENTER(xip == 0);
 
         //set the _tls_array to point to the self_addr of TLS section inside the enclave
-        GP_ON_EENTER(td_mngr_set_td(enclave_base_addr, tcs) == false);
+        //GP_ON_EENTER(td_mngr_set_td(enclave_base_addr, tcs) == false);
  
+        // save FS, GS base address
+        arch_prctl(ARCH_GET_FS, (unsigned long)&tcs_sim->saved_fs_base);
+        arch_prctl(ARCH_GET_GS, (unsigned long)&tcs_sim->saved_gs_base);
+
         // Destination depends on STATE
         xip += (uintptr_t)tcs->oentry;
         tcs_sim->tcs_state = TCS_STATE_ACTIVE;
@@ -288,6 +295,10 @@ void _SE3(uintptr_t xax, uintptr_t xbx,
         regs.xbp = p_ssa_gpr->REG(bp_u);
         regs.xsp = p_ssa_gpr->REG(sp_u);
         regs.xip = xip;
+
+        // adjust the FS, GS base address
+        arch_prctl(ARCH_SET_FS, (unsigned long)enclave_base_addr + tcs->ofs_base);
+        arch_prctl(ARCH_SET_GS, (unsigned long)enclave_base_addr + tcs->ogs_base);
 
         load_regs(&regs);
 

--- a/sdk/simulation/urtssim/linux/Makefile
+++ b/sdk/simulation/urtssim/linux/Makefile
@@ -103,9 +103,9 @@ OBJ6 := $(SIM_DIR)/driver_api/driver_api.o \
         $(SIM_DIR)/assembly/linux/lowlib.o \
         $(SIM_DIR)/assembly/linux/sgxsim.o \
         $(SIM_DIR)/uinst/u_instructions.o  \
-        $(SIM_DIR)/uinst/enclave_mngr.o    \
-        $(SIM_DIR)/uinst/linux/set_tls.o   \
-        $(SIM_DIR)/uinst/linux/restore_tls.o
+        $(SIM_DIR)/uinst/enclave_mngr.o 
+        # $(SIM_DIR)/uinst/linux/set_tls.o   \
+        # $(SIM_DIR)/uinst/linux/restore_tls.o
 
 		
 CPP_OBJ := $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ5)

--- a/sdk/trts/linux/trts_pic.h
+++ b/sdk/trts/linux/trts_pic.h
@@ -82,7 +82,7 @@
 #define dtv    SE_WORDSIZE
 #define tls    0 
 .macro READ_TD_DATA offset
-#ifdef SE_SIM
+#ifdef SE_SIM_NO
 /* TLS support in simulation mode
  * see "sdk/simulation/uinst/linux/set_tls.c"
  * and "sdk/simulation/assembly/linux/gnu_tls.h"


### PR DESCRIPTION
The current simulation mode is using a hack to support TLS.
In this patch, prctl syscall is used to change the FS/GS base.