### PR TITLE
Set external to true for aesmd-socket volume

### DIFF
--- a/docker/build/docker-compose.yml
+++ b/docker/build/docker-compose.yml
@@ -62,3 +62,4 @@ services:
 
 volumes:
   aesmd-socket:
+    external: true

--- a/linux/installer/docker/docker-compose.yml
+++ b/linux/installer/docker/docker-compose.yml
@@ -62,3 +62,4 @@ services:
 
 volumes:
   aesmd-socket:
+    external: true


### PR DESCRIPTION
Fixes #657

SInce the volume is created with `docker`, when it is used in `docker-compose` the `external` attribute must be set to `true` as documented in https://docs.docker.com/storage/volumes/#use-a-volume-with-docker-compose:

> A volume may be created directly outside of compose with `docker volume create` and then referenced inside `docker-compose.yml` as follows:
> 
> ```yml
> version: "3.9"
> services:
>   frontend:
>     image: node:lts
>     volumes:
>       - myapp:/home/node/app
> volumes:
>   myapp:
>     external: true
```
 