### PR TITLE
Add missing include for exception_ptr definition

### DIFF
--- a/external/CppMicroServices/framework/src/util/Utils.h
+++ b/external/CppMicroServices/framework/src/util/Utils.h
@@ -25,6 +25,7 @@
 
 #include "cppmicroservices/FrameworkExport.h"
 
+#include <exception>
 #include <string>
 
 namespace cppmicroservices {


### PR DESCRIPTION
Fix #709 

This PR attempts to add the missing `<exception>` definitions.