### PR TITLE
Support setting BINUTILS_DIR as an env var

### DIFF
--- a/buildenv.mk
+++ b/buildenv.mk
@@ -197,9 +197,9 @@ else ifeq ($(MITIGATION-CVE-2020-0551), CF)
 endif
 
 ifneq ($(origin NIX_PATH), environment)
-BINUTILS_DIR = /usr/local/bin
+BINUTILS_DIR ?= /usr/local/bin
 else
-BINUTILS_DIR = $(ROOT_DIR)/external/toolset/nix/
+BINUTILS_DIR ?= $(ROOT_DIR)/external/toolset/nix/
 endif
 
 # enable -B option for all the build

--- a/common/buildenv.mk
+++ b/common/buildenv.mk
@@ -36,7 +36,7 @@ SGX_TRUSTED_LIBRARY_PATH ?= $(SGX_SDK)/lib64
 CC ?= gcc
 CC_VERSION := $(shell $(CC) -dumpversion)
 CC_NO_LESS_THAN_8 := $(shell expr $(CC_VERSION) \>\= "8")
-BINUTILS_DIR := /usr/local/bin
+BINUTILS_DIR ?= /usr/local/bin
 
 MITIGATION_CFLAGS += -B$(BINUTILS_DIR)
 MITIGATION_LDFLAGS += -B$(BINUTILS_DIR)


### PR DESCRIPTION
Useful for cases in which `binutils` is located elsewhere than `/usr/local/bin` and `$(ROOT_DIR)/external/toolset/nix/`. This allows users to set the "custom" location of `binutils` via the `BINUTILS_DIR` environment variable.