### PR TITLE
docker: run aesm with root

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -73,7 +73,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /installer
 COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
 RUN ./sgx_linux_x64_psw*.bin --no-start-aesm
-USER aesmd
+# Run the aesm service as root to ensure its access to /dev/sgx/provision
 WORKDIR /opt/intel/sgxpsw/aesm/
 ENV LD_LIBRARY_PATH=.
 CMD ./aesm_service --no-daemon

--- a/linux/installer/docker/Dockerfile
+++ b/linux/installer/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get install -y \
 # More aesm plugins, e.g libsgx-aesm-quote-ex-plugin, are needed if application requires attestation. See installation guide.
 RUN apt-get install -y libsgx-aesm-launch-plugin
 
-USER aesmd
+# Run the aesm service as root to ensure its access to /dev/sgx/provision
 WORKDIR /opt/intel/sgx-aesm-service/aesm
 ENV LD_LIBRARY_PATH=.
 CMD ./aesm_service --no-daemon


### PR DESCRIPTION
Groups/permissions in container do not always match with host env.
Run aesm with root to ensure access to /dev/sgx_provision

Signed-off-by: Haitao Huang <4699115+haitaohuang@users.noreply.github.com>