### PR TITLE
Replace /bin/cp with cp for nix-build

### DIFF
--- a/buildenv.mk
+++ b/buildenv.mk
@@ -70,7 +70,7 @@ LINUX_UNITTESTS       := $(ROOT_DIR)/unittests
 DCAP_DIR              := $(LINUX_EXTERNAL_DIR)/dcap_source
 LIBUNWIND_DIR         := $(ROOT_DIR)/sdk/cpprt/linux/libunwind
 
-CP    := /bin/cp -f
+CP    := cp -f
 MKDIR := mkdir -p
 STRIP := strip
 OBJCOPY := objcopy

--- a/psw/ae/aesm_service/source/CMakeLists.txt
+++ b/psw/ae/aesm_service/source/CMakeLists.txt
@@ -39,7 +39,7 @@ set(CMAKE_SKIP_BUILD_RPATH true)
 ########## SGX SDK Settings ##########
 set(SGX_ARCH x64)
 execute_process (
-    COMMAND /usr/bin/getconf LONG_BIT
+    COMMAND getconf LONG_BIT
     OUTPUT_VARIABLE LONG_BIT
 )
 


### PR DESCRIPTION
When using nix-build, /bin/cp cannot be found as there's nothing under
/bin except for sh.

Signed-off-by: Sylvain Bellemare <sbellem@gmail.com>

Unless there's a good reason to keep `/bin/cp`, it seems that simply using `cp` is preferable as suggested in https://discourse.nixos.org/t/bin-cp-cannot-be-found-when-using-nix-build/13683/2.