### PR TITLE
Fix Nix detection

### DIFF
--- a/buildenv.mk
+++ b/buildenv.mk
@@ -208,7 +208,7 @@ else ifeq ($(MITIGATION-CVE-2020-0551), CF)
     MITIGATION_LIB_PATH := cve_2020_0551_cf
 endif
 
-ifneq ($(origin NIX_PATH), environment)
+ifneq ($(origin NIX_STORE), environment)
 BINUTILS_DIR ?= /usr/local/bin
 EXT_BINUTILS_DIR = $(ROOT_DIR)/external/toolset/$(DISTR_ID)$(DISTR_VER)
 else

--- a/external/ippcp_internal/Makefile
+++ b/external/ippcp_internal/Makefile
@@ -68,7 +68,7 @@ CHECK_SOURCE :=
 # For reproducibility build in docker, the code should be 
 # prepared before build. So skip the code check to avoid
 # triggering network request 
-ifneq ($(origin NIX_PATH), environment)
+ifneq ($(origin NIX_STORE), environment)
 ifneq ($(PATCH_LOG), SGX.)
 CHECK_SOURCE:= ipp_source
 endif


### PR DESCRIPTION
Detect Nix by probing for the presence of the `NIX_STORE` environment
variable instead of `NIX_PATH`. The latter is only set in a `nix-shell`
session but isn't when building a derivation through `nix-build`. In
contrast, the `NIX_STORE` environment variable is set in both cases.

Companion PR to intel/intel-sgx-ssl#111

Signed-off-by: Vincent Haupert <mail@vincent-haupert.de>
