### PR TITLE
Fix libuwind target with pthreads

### DIFF
--- a/sdk/cpprt/linux/libunwind/src/Makefile.am
+++ b/sdk/cpprt/linux/libunwind/src/Makefile.am
@@ -689,6 +689,10 @@ AM_CPPFLAGS+= -I../../../../../common/inc/internal
 AM_CCASFLAGS = $(AM_CPPFLAGS)
 noinst_HEADERS += unwind/unwind-internal.h
 
+if OS_LINUX
+AM_CPPFLAGS+= -I../../../../../sdk/cpprt/linux/
+endif
+
 EXTRA_DIST =	$(libunwind_la_SOURCES_aarch64)			\
 		$(libunwind_la_SOURCES_arm)			\
 		$(libunwind_la_SOURCES_hppa)			\


### PR DESCRIPTION
To fix:
```
In file included from ../include/libunwind_i.h:52,
                 from os-linux.c:29:
../include/pthread.h:37:10: fatal error: pthread_compat.h: No such file or directory
   37 | #include "pthread_compat.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```