### PR TITLE
Dockerfile: add debian package build

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install  -y \
     ocamlbuild \
     protobuf-compiler \
     python \
+    reprepro \
     wget
 
 # We assume this docker file is invoked with root at the top of linux-sgx repo, see shell scripts for example.
@@ -61,6 +62,7 @@ RUN sh -c 'echo yes | /linux-sgx/linux/installer/bin/sgx_linux_x64_sdk_*.bin'
 WORKDIR /linux-sgx
 RUN make psw_install_pkg
 
+RUN  make deb_local_repo
 
 FROM ubuntu:18.04 as aesm 
 RUN apt-get update && apt-get install -y \
@@ -73,8 +75,26 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /installer
 COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
 RUN ./sgx_linux_x64_psw*.bin --no-start-aesm
-USER aesmd
 WORKDIR /opt/intel/sgxpsw/aesm/
+ENV LD_LIBRARY_PATH=.
+CMD ./aesm_service --no-daemon
+
+FROM ubuntu:18.04 as aesm_deb
+RUN apt-get update && apt-get install -y \
+    libcurl4 \
+    libprotobuf10 \
+    libssl1.1 \
+    make \
+    module-init-tools
+
+WORKDIR /deb_local_repo
+
+COPY --from=builder /linux-sgx/linux/installer/deb/sgx_debian_local_repo/ ./
+RUN echo "deb [trusted=yes arch=amd64] file:///deb_local_repo bionic main">>/etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install -y libsgx-aesm-launch-plugin libsgx-aesm-quote-ex-plugin
+
+WORKDIR /opt/intel/sgx-aesm-service/aesm/
 ENV LD_LIBRARY_PATH=.
 CMD ./aesm_service --no-daemon
 
@@ -91,6 +111,35 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /opt/intel
 COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
 RUN ./sgx_linux_x64_psw*.bin --no-start-aesm
+RUN sh -c 'echo yes | ./sgx_linux_x64_sdk_*.bin'
+
+WORKDIR /opt/intel/sgxsdk/SampleCode/SampleEnclave
+RUN SGX_DEBUG=0 SGX_MODE=HW SGX_PRERELEASE=1 make
+
+RUN adduser -q --disabled-password --gecos "" --no-create-home sgxuser
+USER sgxuser
+
+CMD ./app
+
+
+FROM ubuntu:18.04 as sample_deb
+RUN apt-get update && apt-get install -y \
+    g++ \
+    libcurl4-openssl-dev \
+    libprotobuf-dev \
+    libssl-dev \
+    make \
+    module-init-tools
+
+WORKDIR /deb_local_repo
+
+COPY --from=builder /linux-sgx/linux/installer/deb/sgx_debian_local_repo/ ./
+RUN echo "deb [trusted=yes arch=amd64] file:///deb_local_repo bionic main">>/etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install -y libsgx-urts
+
+WORKDIR /opt/intel
+COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./
 RUN sh -c 'echo yes | ./sgx_linux_x64_sdk_*.bin'
 
 WORKDIR /opt/intel/sgxsdk/SampleCode/SampleEnclave

--- a/docker/build/README.md
+++ b/docker/build/README.md
@@ -33,24 +33,27 @@ $ ./build_and_run_sample_docker.sh
 
 ## Dockerfile
 
-The Dockerfile specifies 3 image build targets:
-1. builder: Builds PSW and SDK bin installers from source. This requires downloading the prebuilt AEs and optimized libs from 01.org.
-2. aesm: Takes the PSW installer from builder to install and run the AESM daemon.
-3. sample: Installs the SDK installer from builder, then builds and runs the SampleEnclave app
+The Dockerfile specifies 5 image build targets:
+1. builder: Builds PSW and SDK bin and debian installers from source.
+2. aesm: Takes the PSW bin installer from builder to install and run the AESM daemon.
+3. sample: Installs the SDK installer and the PSW bin installer from builder. Then builds and runs the SampleEnclave app
+4. aesm_deb: Takes the PSW debian installer from builder to install and run the AESM daemon.
+5. sample_deb: Takes the SDK installer and the PSW debian installer from builder to install. Then builds and runs the SampleEnclave app.
 
 - [build_and_run_aesm_docker.sh](./build_and_run_aesm_docker.sh): Shows how to build and run the AESM image in Docker. This will start the AESM service listening to a named socket, located in /var/run/aesmd in the container and mounted in Docker volume aesmd-socket.
-
+- [build_and_run_aesm_deb_docker.sh](./build_and_run_aesm_deb_docker.sh): Same as above, but with the debian packages for PSW and DCAP.
 - [build_and_run_sample_docker.sh](./build_and_run_sample_docker.sh): Shows how to build and run the SampleEnclave app inside a Docker container with a locally built SGX sample image.
+- [build_and_run_sample_deb_docker.sh](./build_and_run_sample_deb_docker.sh): Same as above, but with the debian packages for PSW.
 
 ## Legacy Launch Control driver and kernel for SGX
 
 All SGX applications need access to the SGX device nodes exposed by the kernel space driver. Depending on the driver or kernel you are using, the SGX device nodes may have different names and locations. Therefore, you need to ensure those nodes are mapped and mounted inside the containers properly.
 
 
-[SGX kernel patches](https://github.com/jsakkine-intel/linux-sgx/commits/master) are still in process of upstreaming.
-The [Flexible Launch Control driver](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver) is developed to imitate the kernel patches as closely as possible.
+[SGX kernel patches](https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/log/?h=x86/sgx) are upstream now and included in main line kernel release 5.11 or later.
+The [Flexible Launch Control driver](https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver) is developed to imitate the kernel patches as closely as possible. It can be used for distros with kernels older than 5.11.
 
-The sample scripts and Compose files are compatible with the Flexible Launch Control driver or a custom built kernel with SGX support. If you need to use the Legacy Launch Control driver then you need to make following modifications:
+The sample scripts and Compose files are compatible with the Flexible Launch Control driver or a custom built kernel with SGX support. To use the Legacy Launch Control driver, make following modifications:
 1. Replace "/dev/sgx/enclave" device with "/dev/isgx" and **remove** "/dev/sgx/provision" device for AESM in docker-compose.yml and build_and_run_aesm_docker.sh
 2. Replace "/dev/sgx/enclave" with "/dev/isgx" for the sample container in docker-compose.yml and build_and_run_sample_docker.sh
 

--- a/docker/build/build_and_run_aesm_deb_docker.sh
+++ b/docker/build/build_and_run_aesm_deb_docker.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Copyright (C) 2022 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target aesm_deb --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_aesm_deb -f ./Dockerfile ../../
+
+docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=rw aesmd-socket
+
+# If you use the Legacy Launch Control driver, replace /dev/sgx/enclave with /dev/isgx, and remove
+# --device=/dev/sgx/provision
+
+docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave --device=/dev/sgx/provision -v /dev/log:/dev/log -v aesmd-socket:/var/run/aesmd -it sgx_aesm_deb

--- a/docker/build/build_and_run_sample_deb_docker.sh
+++ b/docker/build/build_and_run_sample_deb_docker.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (C) 2022 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+docker build --target sample_deb --build-arg https_proxy=$https_proxy \
+             --build-arg http_proxy=$http_proxy -t sgx_sample_deb -f ./Dockerfile ../../
+
+# Another container should expose AESM and its socket in aesmd-socket volume.
+# Replace /dev/sgx/enclave with /dev/isgx if you use the Legacy Launch Control driver
+docker run --env http_proxy --env https_proxy --device=/dev/sgx/enclave -v aesmd-socket:/var/run/aesmd -it sgx_sample_deb

--- a/linux/installer/docker/Dockerfile
+++ b/linux/installer/docker/Dockerfile
@@ -77,7 +77,6 @@ RUN apt-get install -y \
 # More aesm plugins, e.g libsgx-aesm-quote-ex-plugin, are needed if application requires attestation. See installation guide.
 RUN apt-get install -y libsgx-aesm-launch-plugin
 
-USER aesmd
 WORKDIR /opt/intel/sgx-aesm-service/aesm
 ENV LD_LIBRARY_PATH=.
 CMD ./aesm_service --no-daemon


### PR DESCRIPTION
Also revert aesm docker to run as root inside
This was to ensure access to /dev/sgx_provision

Signed-off-by: Haitao Huang <4699115+haitaohuang@users.noreply.github.com>