### PR TITLE
Fixing SGX GDB not working because dyn_sec/elrange_start_address pointer is zero

### DIFF
--- a/sdk/debugger_interface/linux/gdb-sgx-plugin/gdb_sgx_plugin.py
+++ b/sdk/debugger_interface/linux/gdb-sgx-plugin/gdb_sgx_plugin.py
@@ -416,7 +416,7 @@ def retrieve_enclave_info(info_addr = 0):
             td_fmt = '4Q'
 
         #get thread_data_t address
-        if (info_tuple[8] == info_tuple[1]) or ((info_tuple[3] & ET_SIM) == ET_SIM):
+        if (info_tuple[8] == 0) or (info_tuple[8] == info_tuple[1]) or ((info_tuple[3] & ET_SIM) == ET_SIM):
             td_addr = tcs_t_tuple[7] + info_tuple[1]     #thread_data_t = tcs.of_base + debug_enclave_info.start_addr
         else:
             td_addr = tcs_t_tuple[7] + info_tuple[8]     #thread_data_t = tcs.of_base + debug_enclave_info.elrange_start_address


### PR DESCRIPTION
Recently I faced an issue that sgx-gdb refuses to load symbol and add breakpoints on enclave even though it has been properly compiled in hardware debug mode. The symptom are like in this GDB output

![image](https://user-images.githubusercontent.com/7830940/162313790-00acd0b4-7a9b-4ca2-80bb-522f68c74288.png)

After further investigation to the Python script, the error message came from around this code in function `retrieve_enclave_info`

https://github.com/intel/linux-sgx/blob/edfe42a517b3e4b1d81204c3cdef6da6cb35fefc/sdk/debugger_interface/linux/gdb-sgx-plugin/gdb_sgx_plugin.py#L419-L424

Where the `td_addr` tried to load `thread_data_t` from invalid address. Looking up further, `td_addr` is computed by adding `tcs_t_tuple[7]`, which is `tcs.of_base` and `info_tuple[8]` which is `debug_enclave_info.elrange_start_address`. 

From my examination, `debug_enclave_info.elrange_start_address` has 0 value, yet the if is evaluated as false since `debug_enclave_info.elrange_start_address != debug_enclave_info.start_addr`. Meanwhile, `debug_enclave_info.start_addr` is actually store the actual start `mmap`ed address of the enclave. This results in the `td_addr` to be calculated with 0 offset, hence resulting invalid address when the `retrieve_enclave_info` tried to load the information from the `thread_data` object inside the enclave memor.

Fixing this is simply adding the if clause to check whether the `info_tuple[8]` or `elrange_start_address` equals to 0, then it automatically uses `info_tuple[1]` value, which is the `start_addr`. Below is the result from GDB

![image](https://user-images.githubusercontent.com/7830940/162319706-df61f353-5e8a-44de-9db0-58a7bbcda14e.png)
