### PR TITLE
fix a issue for vdso

### DIFF
--- a/psw/urts/linux/sig_handler.cpp
+++ b/psw/urts/linux/sig_handler.cpp
@@ -353,10 +353,11 @@ static int sgx_urts_vdso_handler(long rdi, long rsi, long rdx, long ursp, long r
                 return 0;
             }
             //move the ocall return result to rsi and set rdi to ECMD_ORET for ocall return to trts
-            __asm__ __volatile__("mov %%rax, %%rsi\n"
-                    "mov %0, %%rdi\n"
+            __asm__ __volatile__("mov $0, %%rsi\n"
+                    "movl %0, %%esi\n"
+                    "mov %1, %%rdi\n"
                     :
-                    :"i"(ECMD_ORET)
+                    :"r"(status),"i"(ECMD_ORET)
                     :"rsi","rdi");
             return SE_EENTER;
         }


### PR DESCRIPTION
One thing that caught my eye in the following snippet that Ming-Wei linked to

[https://github.com/intel/linux-sgx/blob/1a98debccc9c8a365ddedc1c9b352cdbc216f598/psw/urts/linux/sig_handler.cpp#L361]
is that the assembly snippet uses the RAX register while the compiler is not required to preserve the RAX value (ocall return code) at that point.
Here is an illustrative example to show compiler clearing RAX before a similar snippet: https://godbolt.org/z/EG4z6qnMs

Signed-off-by: junjungu <junjun.gu@intel.com>