### PR TITLE
[FIX] Memory leak in _pthread_tls_destructors

### DIFF
--- a/sdk/pthread/pthread_tls.cpp
+++ b/sdk/pthread/pthread_tls.cpp
@@ -173,7 +173,7 @@ void _pthread_tls_destructors(void)
     struct sgx_pthread_storage *rs;
     int i;
 
-    if(NULL == pthread_info_tls.m_pthread)
+    if(NULL == pthread_info_tls.m_local_storage)
         //do nothing
         return;
 


### PR DESCRIPTION
`_pthread_tls_destructors` checks if the m_pthread value is not `NULL`. However, there are cases where the enclave code does not spawn a thread, but make a proper call to pthread TLS infrastructure. If so, the linked-list storing the TLS is not properly cleaned up after enclave exit.

This is the case found when using OpenSSL library, particularly when integrating the libssl into the SGX enclave to allow terminating SSL connection inside the enclave. We found the case when performing stress-testing on unit-test function of our implementation that uses OpenSSL's TLS.

**Additional background:** I developed a valgrind-like infrastructure to check memory leak inside the enclave while running in the hardware-debug mode. Below is the result of the memory allocation trace for the leaked memory

```
#0 - __morestack 
#1 - gmhmd_core_Memcheck_alloc 
#2 - __wrap_calloc 
#3 - _pthread_findstorage 
#4 - pthread_getspecific 
#5 - ossl_init_thread_start 
#6 - ERR_get_state 
#7 - ERR_clear_error 
#8 - state_machine.part 
#9 - gmhmd_core_TLSConnectionHandler 
#10 - sgx_gmhmd_core_TLSConnectionHandler 
#11 - do_ecall
```

```
#0 - __morestack 
#1 - gmhmd_core_Memcheck_alloc 
#2 - __wrap_calloc 
#3 - _pthread_findstorage 
#4 - pthread_getspecific 
#5 - OPENSSL_thread_stop 
#6 - gmhmd::TLSConnection::~TLSConnection 
#7 - gmhmd_core_RestAPISendResponse 
#8 - sgx_gmhmd_core_RestAPISendResponse 
#9 - do_ecall
```

OpenSSL uses thread local storage to store its error information, similar to `errno` in POSIX system, and to allow it to be thread-safe. Therefore, the OpenSSL library will call pthread's function to store values in thread local. Since SGX's pthread implementation does not check if a thread is created **inside** or **outside** the enclave while storing value in thread local storage, the `pthread_info_tls.m_pthread` will stay `NULL` at the destruction point where it is being checked.

https://github.com/intel/linux-sgx/blob/e1a37bdc381672509e49e34885730437366194e4/sdk/pthread/pthread_tls.cpp#L171-L178

OpenSSL supports calling `OPENSSL_thread_stop` to perform manual clean-up especially in the case where the destructor is not bound to the thread destructor, in some specific case like statically linking OpenSSL to the executable. But in here, it is not the case since the leak is actually due to the SGX pthread implementation does not properly clean up the thread local storage before exiting the enclave. Which funnily, calling `OPENSSL_thread_stop` adds additional thread-local storage since it is seeking a key that is not available yet in the linked-list.

The fix is simple, instead checking `m_pthread`, it must check `m_local_storage` for its `NULL` value on the destruction. Logically, `m_pthread` is also not involved in any part of the destructor; only the linked-list that is stored in `m_local_storage`, as well as calling the provided destructor if it is available. So, checking `m_pthread` in here is also logically incorrect since the `m_pthread` value is not synchronized with `m_local_storage`. 

By fixing this, OpenSSL also does not require to call `OPENSSL_thread_stop` to perform manual cleanup on thread/ECALL termination, and the memory leak is disappear.