### PR TITLE
Enable parallelization of build in dnnl make file

### DIFF
--- a/external/dnnl/Makefile
+++ b/external/dnnl/Makefile
@@ -89,7 +89,7 @@ else
 endif
 
 $(LIBDNNL):$(CHECK_SOURCE)
-	mkdir -p $(DNNL_DIR)/build && cd $(DNNL_DIR)/build && cmake -DCMAKE_CXX_ENCLAVE_FLAGS="$(CXX_ENCLAVE_FLAGS)" -DCMAKE_C_ENCLAVE_FLAGS="$(C_ENCLAVE_FLAGS)" $(DNNL_CONFIG) .. && make
+	mkdir -p $(DNNL_DIR)/build && cd $(DNNL_DIR)/build && cmake -DCMAKE_CXX_ENCLAVE_FLAGS="$(CXX_ENCLAVE_FLAGS)" -DCMAKE_C_ENCLAVE_FLAGS="$(C_ENCLAVE_FLAGS)" $(DNNL_CONFIG) .. && $(MAKE)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The current Makefile does not use the special `$(MAKE)` command, instead `make` is hard coded.
This prevents the use of the `-j` flag, making the build slow.

Signed-off-by: Muhammad El-Hindi <muhammad.el-hindi@cs.tu-darmstadt.com>