### PR TITLE
Fix aesmd booting error after RPM upgrade.

### DIFF
--- a/linux/installer/rpm/sgx-aesm-service/sgx-aesm-service.spec
+++ b/linux/installer/rpm/sgx-aesm-service/sgx-aesm-service.spec
@@ -67,7 +67,7 @@ sed -i 's#^/etc/aesmd.conf#%config &#' %{_specdir}/list-%{name}
 
 %files -f %{_specdir}/list-%{name}
 
-%post
+%posttrans
 if [ -x %{_install_path}/startup.sh ]; then %{_install_path}/startup.sh; fi
 
 %preun


### PR DESCRIPTION
According to the spec [1], the scriptlet %post of a new package executes
before %preun of the old package.

This will cause the startup.sh of the new package to be executed first,
and then the cleanup.sh of the old package to be executed when
sgx-aesm-service is upgraded, and the user aesmd will be deleted,
which leading aesmd booting error.

Replace %post with %posttrans to make sure the prerequisites for service
aesmd are met.

[1]. https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/

Signed-off-by: yuguorui <yuguorui@pku.edu.cn>