### PR TITLE
Fix pthread_self for untrusted threads that Ecall

### DIFF
--- a/sdk/pthread/pthread.cpp
+++ b/sdk/pthread/pthread.cpp
@@ -364,7 +364,12 @@ int pthread_join(pthread_t thread, void **retval)
  */
 pthread_t pthread_self(void)
 {
-    return (pthread_t)(pthread_info_tls.m_pthread);
+    pthread_t t = (pthread_t)(pthread_info_tls.m_pthread);
+    // For threads that are created outside enclave t value is NULL
+    if (!t) { 
+        return (pthread_t)(sgx_thread_self());
+    }
+    return t;
 }
 
 /*


### PR DESCRIPTION
Only threads created inside Enclave have pthread_info_tls.m_pthread set. If some untrusted thread does Ecall and then pthread_self() within Enclave, it will return NULL. This errorneous return value ends up causing thread synchronization errors inside the Enclave.