### PR TITLE
Fixed minor typo in key definitions

### DIFF
--- a/common/inc/sgx_key.h
+++ b/common/inc/sgx_key.h
@@ -51,7 +51,7 @@
 
 /* Key Policy */
 #define SGX_KEYPOLICY_MRENCLAVE        0x0001      /* Derive key using the enclave's ENCLAVE measurement register */
-#define SGX_KEYPOLICY_MRSIGNER         0x0002      /* Derive key using the enclave's SINGER measurement register */
+#define SGX_KEYPOLICY_MRSIGNER         0x0002      /* Derive key using the enclave's SIGNER measurement register */
 #define SGX_KEYPOLICY_NOISVPRODID      0x0004      /* Derive key without the enclave's ISVPRODID */
 #define SGX_KEYPOLICY_CONFIGID         0x0008      /* Derive key with the enclave's CONFIGID */
 #define SGX_KEYPOLICY_ISVFAMILYID      0x0010      /* Derive key with the enclave's ISVFAMILYID */

--- a/common/inc/sgx_tseal.h
+++ b/common/inc/sgx_tseal.h
@@ -56,7 +56,7 @@ typedef struct _aes_gcm_data_t
 typedef struct _sealed_data_t
 {
     sgx_key_request_t  key_request;       /* 00: The key request used to obtain the sealing key */
-    uint32_t           plain_text_offset; /* 64: Offset within aes_data.playload to the start of the optional additional MAC text */
+    uint32_t           plain_text_offset; /* 64: Offset within aes_data.payload to the start of the optional additional MAC text */
     uint8_t            reserved[12];      /* 68: Reserved bits */
     sgx_aes_gcm_data_t aes_data;          /* 80: Data structure holding the AES/GCM related data */
 } sgx_sealed_data_t;


### PR DESCRIPTION
One comment should be reading SIGNER and not SINGER.


Signed-off-by: Camila Fonseca <inrymail@gmail.com>