### PR TITLE
Remove redundant hunk in protobuf patch

### DIFF
--- a/external/protobuf/sgx_protobuf.patch
+++ b/external/protobuf/sgx_protobuf.patch
@@ -7,7 +7,6 @@ Subject: [PATCH] Enable Protobuf in SGX
  cmake/CMakeLists.txt                          |  31 +++-
  cmake/libsgx_protobuf.cmake                   | 140 ++++++++++++++++++
  configure.ac                                  |   2 +-
- .../google/protobuf/MessageReflection.java    |  26 +++-
  .../protobuf/io/zero_copy_stream_impl.cc      |   6 +
  .../protobuf/io/zero_copy_stream_impl.h       |   4 +-
  src/google/protobuf/map.h                     |  12 ++
@@ -247,77 +246,6 @@ index 7c5c2c799..31c63629f 100644
  
  # Check whether the linker supports version scripts
  AC_MSG_CHECKING([whether the linker supports version scripts])
-diff --git a/java/core/src/main/java/com/google/protobuf/MessageReflection.java b/java/core/src/main/java/com/google/protobuf/MessageReflection.java
-index b7f5d52d4..f032d4926 100644
---- a/java/core/src/main/java/com/google/protobuf/MessageReflection.java
-+++ b/java/core/src/main/java/com/google/protobuf/MessageReflection.java
-@@ -349,6 +349,7 @@ class MessageReflection {
-   static class BuilderAdapter implements MergeTarget {
- 
-     private final Message.Builder builder;
-+    private boolean hasNestedBuilders = true;
- 
-     @Override
-     public Descriptors.Descriptor getDescriptorForType() {
-@@ -363,6 +364,17 @@ class MessageReflection {
-     public Object getField(Descriptors.FieldDescriptor field) {
-       return builder.getField(field);
-     }
-+    
-+    private Message.Builder getFieldBuilder(Descriptors.FieldDescriptor field) {
-+      if (hasNestedBuilders) {
-+        try {
-+          return builder.getFieldBuilder(field);
-+        } catch (UnsupportedOperationException e) {
-+          hasNestedBuilders = false;
-+        }
-+      }
-+      return null;
-+    }
- 
-     @Override
-     public boolean hasField(Descriptors.FieldDescriptor field) {
-@@ -371,6 +383,12 @@ class MessageReflection {
- 
-     @Override
-     public MergeTarget setField(Descriptors.FieldDescriptor field, Object value) {
-+      if (!field.isRepeated() && value instanceof MessageLite.Builder) {
-+        if (value != getFieldBuilder(field)) {
-+          builder.setField(field, ((MessageLite.Builder) value).buildPartial());
-+        }
-+        return this;
-+      }
-       builder.setField(field, value);
-       return this;
-     }
-@@ -384,12 +402,18 @@ class MessageReflection {
-     @Override
-     public MergeTarget setRepeatedField(
-         Descriptors.FieldDescriptor field, int index, Object value) {
-+      if (value instanceof MessageLite.Builder) {
-+        value = ((MessageLite.Builder) value).buildPartial();
-+      }
-       builder.setRepeatedField(field, index, value);
-       return this;
-     }
- 
-     @Override
-     public MergeTarget addRepeatedField(Descriptors.FieldDescriptor field, Object value) {
-+      if (value instanceof MessageLite.Builder) {
-+        value = ((MessageLite.Builder) value).buildPartial();
-+      }
-       builder.addRepeatedField(field, value);
-       return this;
-     }
-@@ -543,7 +567,7 @@ class MessageReflection {
- 
-     @Override
-     public Object finish() {
--      return builder.buildPartial();
-+      return builder;
-     }
-   }
- 
 diff --git a/src/google/protobuf/io/zero_copy_stream_impl.cc b/src/google/protobuf/io/zero_copy_stream_impl.cc
 index c66bc862a..1fee728cd 100644
 --- a/src/google/protobuf/io/zero_copy_stream_impl.cc


### PR DESCRIPTION
In 2.21, the `sgx_prototype.patch` patch was updated, see changes here: https://github.com/intel/linux-sgx/commit/f47d0e5a01bf68cebefce4418cf364777e76d503#diff-98904cd6b1061edb9917b625b87e4327e06a652c60eef99e8618f099122a86b4R250-R320

However, in the `3.20.x` protobuf branch, one hunk was already checked in: https://github.com/protocolbuffers/protobuf/blob/3.20.x/java/core/src/main/java/com/google/protobuf/MessageReflection.java#L415

This causes `make` to break because the hunk is already applied and can't find an appropriate area to insert this hunk (see repro steps)

Reproduction steps:
```
➜  linux-sgx git:(master) rm -rf external/protobuf/protobuf_code
➜  linux-sgx git:(master) ✗ git clone -b 3.20.x https://github.com/protocolbuffers/protobuf.git external/protobuf/protobuf_code
Cloning into 'external/protobuf/protobuf_code'...
remote: Enumerating objects: 155619, done.
remote: Counting objects: 100% (162/162), done.
remote: Compressing objects: 100% (99/99), done.
remote: Total 155619 (delta 70), reused 121 (delta 55), pack-reused 155457
Receiving objects: 100% (155619/155619), 134.28 MiB | 18.71 MiB/s, done.
Resolving deltas: 100% (111626/111626), done.

➜  linux-sgx git:(master) cd external/protobuf/protobuf_code

➜  protobuf_code git:(3.20.x) pwd
/Users/kevinhui/linux-sgx/external/protobuf/protobuf_code

➜  protobuf_code git:(3.20.x) git apply ../sgx_protobuf.patch --check -v
Checking patch cmake/CMakeLists.txt...
Checking patch cmake/libsgx_protobuf.cmake...
Checking patch configure.ac...
Checking patch java/core/src/main/java/com/google/protobuf/MessageReflection.java...
error: while searching for:
  static class BuilderAdapter implements MergeTarget {

    private final Message.Builder builder;

    @Override
    public Descriptors.Descriptor getDescriptorForType() {

error: patch failed: java/core/src/main/java/com/google/protobuf/MessageReflection.java:349
error: java/core/src/main/java/com/google/protobuf/MessageReflection.java: patch does not apply
Checking patch src/google/protobuf/io/zero_copy_stream_impl.cc...
Checking patch src/google/protobuf/io/zero_copy_stream_impl.h...
Checking patch src/google/protobuf/map.h...
Checking patch src/google/protobuf/message_lite.cc...
Checking patch src/google/protobuf/message_lite.h...
Checking patch src/google/protobuf/port_def.inc...
Checking patch src/google/protobuf/repeated_ptr_field.h...
Checking patch src/google/protobuf/stubs/common.cc...
Checking patch src/google/protobuf/stubs/int128.cc...
Checking patch src/google/protobuf/stubs/int128.h...
Checking patch src/google/protobuf/stubs/port.h...
Checking patch src/google/protobuf/stubs/status.cc...
Checking patch src/google/protobuf/stubs/status.h...
Checking patch src/google/protobuf/stubs/stringpiece.cc...
Checking patch src/google/protobuf/stubs/stringpiece.h...
Checking patch src/google/protobuf/stubs/strutil.cc...
Checking patch src/google/protobuf/stubs/time.cc...
Checking patch src/google/protobuf/text_format.cc...
Checking patch src/google/protobuf/util/delimited_message_util.cc...
Checking patch src/google/protobuf/util/delimited_message_util.h...
Checking patch src/google/protobuf/util/time_util.h...
```

With this commit, the patch works:
```
➜  protobuf_code git:(3.20.x) git apply ../sgx_protobuf.patch --check -v
Checking patch cmake/CMakeLists.txt...
Checking patch cmake/libsgx_protobuf.cmake...
Checking patch configure.ac...
Checking patch src/google/protobuf/io/zero_copy_stream_impl.cc...
Checking patch src/google/protobuf/io/zero_copy_stream_impl.h...
Checking patch src/google/protobuf/map.h...
Checking patch src/google/protobuf/message_lite.cc...
Checking patch src/google/protobuf/message_lite.h...
Checking patch src/google/protobuf/port_def.inc...
Checking patch src/google/protobuf/repeated_ptr_field.h...
Checking patch src/google/protobuf/stubs/common.cc...
Checking patch src/google/protobuf/stubs/int128.cc...
Checking patch src/google/protobuf/stubs/int128.h...
Checking patch src/google/protobuf/stubs/port.h...
Checking patch src/google/protobuf/stubs/status.cc...
Checking patch src/google/protobuf/stubs/status.h...
Checking patch src/google/protobuf/stubs/stringpiece.cc...
Checking patch src/google/protobuf/stubs/stringpiece.h...
Checking patch src/google/protobuf/stubs/strutil.cc...
Checking patch src/google/protobuf/stubs/time.cc...
Checking patch src/google/protobuf/text_format.cc...
Checking patch src/google/protobuf/util/delimited_message_util.cc...
Checking patch src/google/protobuf/util/delimited_message_util.h...
Checking patch src/google/protobuf/util/time_util.h...
➜  protobuf_code git:(3.20.x) echo $?
0
```