### PR TITLE
Fix memory leak in sign_tool.cpp

### DIFF
--- a/sdk/sign_tool/SignTool/sign_tool.cpp
+++ b/sdk/sign_tool/SignTool/sign_tool.cpp
@@ -100,7 +100,9 @@ typedef enum _file_path_t
 static int load_enclave(BinParser *parser, metadata_t *metadata)
 {
     std::unique_ptr<CLoader> ploader(new CLoader(const_cast<uint8_t *>(parser->get_start_addr()), *parser));
-    return ploader->load_enclave_ex(NULL, 0, metadata, NULL,  0, NULL);
+    int ret = ploader->load_enclave_ex(NULL, 0, metadata, NULL,  0, NULL);
+    delete parser;
+    return ret;
 }
 
 


### PR DESCRIPTION
Ownership of the parser is transferred from measure_enclave() to load_enclave(). load_enclave() passes the parser by reference to the CLoader constructor. CLoader cannot be responsible for deleting the parser. The parser must be deleted at the end of load_enclave().