### PR TITLE
Fix misused tabs in Makefiles

### DIFF
--- a/SampleCode/Switchless/Makefile
+++ b/SampleCode/Switchless/Makefile
@@ -37,21 +37,21 @@ SGX_ARCH ?= x64
 SGX_DEBUG ?= 1
 
 ifeq ($(shell getconf LONG_BIT), 32)
-	SGX_ARCH := x86
+    SGX_ARCH := x86
 else ifeq ($(findstring -m32, $(CXXFLAGS)), -m32)
-	SGX_ARCH := x86
+    SGX_ARCH := x86
 endif
 
 ifeq ($(SGX_ARCH), x86)
-	SGX_COMMON_FLAGS := -m32
-	SGX_LIBRARY_PATH := $(SGX_SDK)/lib
-	SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x86/sgx_sign
-	SGX_EDGER8R := $(SGX_SDK)/bin/x86/sgx_edger8r
+    SGX_COMMON_FLAGS := -m32
+    SGX_LIBRARY_PATH := $(SGX_SDK)/lib
+    SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x86/sgx_sign
+    SGX_EDGER8R := $(SGX_SDK)/bin/x86/sgx_edger8r
 else
-	SGX_COMMON_FLAGS := -m64
-	SGX_LIBRARY_PATH := $(SGX_SDK)/lib64
-	SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x64/sgx_sign
-	SGX_EDGER8R := $(SGX_SDK)/bin/x64/sgx_edger8r
+    SGX_COMMON_FLAGS := -m64
+    SGX_LIBRARY_PATH := $(SGX_SDK)/lib64
+    SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x64/sgx_sign
+    SGX_EDGER8R := $(SGX_SDK)/bin/x64/sgx_edger8r
 endif
 
 ifeq ($(SGX_DEBUG), 1)
@@ -61,9 +61,9 @@ endif
 endif
 
 ifeq ($(SGX_DEBUG), 1)
-	SGX_COMMON_FLAGS += -O0 -g
+    SGX_COMMON_FLAGS += -O0 -g
 else
-	SGX_COMMON_FLAGS += -O2
+    SGX_COMMON_FLAGS += -O2
 endif
 
 SGX_COMMON_FLAGS += -Wall -Wextra -Winit-self -Wpointer-arith -Wreturn-type \
@@ -76,9 +76,9 @@ SGX_COMMON_CXXFLAGS := $(SGX_COMMON_FLAGS) -Wnon-virtual-dtor -std=c++11
 ######## App Settings ########
 
 ifneq ($(SGX_MODE), HW)
-	Urts_Library_Name := sgx_urts_sim
+    Urts_Library_Name := sgx_urts_sim
 else
-	Urts_Library_Name := sgx_urts
+    Urts_Library_Name := sgx_urts
 endif
 
 App_Cpp_Files := App/App.cpp
@@ -111,11 +111,11 @@ App_Name := app
 ######## Enclave Settings ########
 
 ifneq ($(SGX_MODE), HW)
-	Trts_Library_Name := sgx_trts_sim
-	Service_Library_Name := sgx_tservice_sim
+    Trts_Library_Name := sgx_trts_sim
+    Service_Library_Name := sgx_tservice_sim
 else
-	Trts_Library_Name := sgx_trts
-	Service_Library_Name := sgx_tservice
+    Trts_Library_Name := sgx_trts
+    Service_Library_Name := sgx_tservice
 endif
 Crypto_Library_Name := sgx_tcrypto
 

--- a/psw/ae/aesm_service/Makefile
+++ b/psw/ae/aesm_service/Makefile
@@ -47,14 +47,14 @@ ifeq ($(BUILD_REF_LE), 1)
 endif
 
 ifeq ($(ARCH), x86)
-	SQLITECFLAGS += -m32
+    SQLITECFLAGS += -m32
 else
-	SQLITECFLAGS += -m64
+    SQLITECFLAGS += -m64
 endif
 
 ifdef PROFILE
-	CXXFLAGS += -D_PROFILE_
-	CFLAGS += -D_PROFILE_
+    CXXFLAGS += -D_PROFILE_
+    CFLAGS += -D_PROFILE_
 endif
 
 CXXFLAGS += -fpie

--- a/sdk/debugger_interface/linux/Makefile
+++ b/sdk/debugger_interface/linux/Makefile
@@ -39,9 +39,9 @@ CPPFLAGS += -I$(COMMON_DIR)/inc/           \
 
 CFLAGS += -W -Wall -Werror -D_GNU_SOURCE -fpic
 ifeq ($(CC_BELOW_4_9), 1)
-	CFLAGS += -fstack-protector
+    CFLAGS += -fstack-protector
 else
-	CFLAGS += -fstack-protector-strong
+    CFLAGS += -fstack-protector-strong
 endif
 LDLIBS += -ldl
 

--- a/sdk/protected_code_loader/Makefile
+++ b/sdk/protected_code_loader/Makefile
@@ -34,16 +34,16 @@
 include ../../buildenv.mk
 
 ifndef VERBOSE
-	PCLVERBOSE := @
+    PCLVERBOSE := @
 else
-	PCLVERBOSE :=
+    PCLVERBOSE :=
 endif
 
 # optimize bug on GCC 13.3.2, we need to disable optimize when build with GCC 13.3.2
 CC_NO_LESS_THAN_13 := $(shell expr $(CC_VERSION) \>\= "13")
 
 ifeq ($(ARCH), x86)
-	$(error x86 build is not supported, only x64!!)
+    $(error x86 build is not supported, only x64!!)
 endif
 
 # output dir for simulation build objects

--- a/sdk/tlibcrypto/Makefile
+++ b/sdk/tlibcrypto/Makefile
@@ -34,7 +34,7 @@ include ../../buildenv.mk
 CPPFLAGS := -I$(COMMON_DIR)/inc/internal \
             -I$(COMMON_DIR)/inc          \
             -I$(COMMON_DIR)/inc/tlibc    \
-	    -I$(SGX_IPP_INC)
+            -I$(SGX_IPP_INC)
 
 CXXFLAGS += $(ENCLAVE_CXXFLAGS) -fno-exceptions -fno-rtti #-Werror
 
@@ -44,9 +44,9 @@ SHARED_OBJ = tcrypto_version.o sgx_common_init_ipp.o
 ifeq ($(USE_CRYPTO_LIB), 0)
 # Build SGXSSL based sgx_tcrypto library
 ifeq ($(ARCH), x86_64)
-	OPENSSL_PACKAGE = $(LINUX_EXTERNAL_DIR)/sgxssl/Linux/package
+    OPENSSL_PACKAGE = $(LINUX_EXTERNAL_DIR)/sgxssl/Linux/package
 else
-	$(error SGXSSL doesn't support 32bit)
+    $(error SGXSSL doesn't support 32bit)
 endif #($(ARCH), x86_64)
 
 ifeq ($(MITIGATION-CVE-2020-0551), LOAD)
@@ -58,12 +58,12 @@ OPENSSL_LIBRARY_PATH := $(OPENSSL_PACKAGE)/lib64
 endif
 
 ifdef DEBUG
-	OpenSSL_Crypto_Library_Name := sgx_tsgxssl_cryptod
-	SGXSSL_Library_Name := sgx_tsgxssld
-	SGX_COMMON_CFLAGS += -O0
+    OpenSSL_Crypto_Library_Name := sgx_tsgxssl_cryptod
+    SGXSSL_Library_Name := sgx_tsgxssld
+    SGX_COMMON_CFLAGS += -O0
 else
-	OpenSSL_Crypto_Library_Name := sgx_tsgxssl_crypto
-	SGXSSL_Library_Name := sgx_tsgxssl
+    OpenSSL_Crypto_Library_Name := sgx_tsgxssl_crypto
+    SGXSSL_Library_Name := sgx_tsgxssl
 endif
 
 PREPARE_SGXSSL := $(LINUX_EXTERNAL_DIR)/sgxssl/prepare_sgxssl.sh


### PR DESCRIPTION
Makefile use tabs to identify the lines of recipes. If using tabs in a non-recipe part, it may complain `‘recipe commences before first target. Stop.` ([Makefile manual](https://www.gnu.org/software/make/manual/html_node/Error-Messages.html#Error-Messages)) and quits.