### PR TITLE
Update __config to make clangd happy

### DIFF
--- a/sdk/tlibcxx/include/__config
+++ b/sdk/tlibcxx/include/__config
@@ -181,13 +181,13 @@
 #define __has_include(...) 0
 #endif
 
-#if defined(__clang__)
+#if defined(__GNUC__)
+#  define _LIBCPP_COMPILER_GCC
+#elif defined(__clang__)
 #  define _LIBCPP_COMPILER_CLANG
 #  ifndef __apple_build_version__
 #    define _LIBCPP_CLANG_VER (__clang_major__ * 100 + __clang_minor__)
 #  endif
-#elif defined(__GNUC__)
-#  define _LIBCPP_COMPILER_GCC
 #elif defined(_MSC_VER)
 #  define _LIBCPP_COMPILER_MSVC
 #elif defined(__IBMCPP__)

--- a/sdk/tlibcxx/include/variant
+++ b/sdk/tlibcxx/include/variant
@@ -234,7 +234,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // TODO: GCC 5 lies about its support for C++17 (it says it supports it but it
 //       really doesn't). That breaks variant, which uses some C++17 features.
 //       Remove this once we drop support for GCC 5.
-#if _LIBCPP_STD_VER > 14 && !(defined(_LIBCPP_COMPILER_GCC) && _GNUC_VER_NEW < 6000)
+#if _LIBCPP_STD_VER > 14
 
 _LIBCPP_NORETURN
 inline _LIBCPP_INLINE_VISIBILITY


### PR DESCRIPTION
The sgx-sdk uses _LIBCPP_COMPILER_GCC macro to modify the stl. However, when using clangd, the language sever defines __clang__ macro, so that if matches __clang__ first, the _LIBCPP_COMPILER_GCC will not be defined, thus causing clangd to report error.