### PR TITLE
Fix assembler call frame information (CFI) directives

### DIFF
--- a/common/inc/internal/linux/linux-regs.h
+++ b/common/inc/internal/linux/linux-regs.h
@@ -144,6 +144,7 @@
     .globl \name
     .type \name, @function
 \name:
+    .cfi_startproc
     _CET_ENDBR
 .endm
 
@@ -153,6 +154,7 @@
     .hidden \name
     .type \name, @function
 \name:
+    .cfi_startproc
     _CET_ENDBR
 .endm
 
@@ -215,7 +217,6 @@
 /*******************************************************************/
 
 .macro SE_PROLOG
-    .cfi_startproc
 
 #ifdef LINUX32
     pushl   %ebp

--- a/common/src/linux/xsave_gnu.S
+++ b/common/src/linux/xsave_gnu.S
@@ -101,6 +101,7 @@ DECLARE_LOCAL_FUNC restore_xregs
     DO_FXRSTOR
 2:
     ret
+    .cfi_endproc
 
 DECLARE_LOCAL_FUNC save_xregs
 #if defined(LINUX32)
@@ -121,4 +122,5 @@ DECLARE_LOCAL_FUNC save_xregs
     DO_FXSAVE
 2:
     ret
+    .cfi_endproc
 

--- a/psw/urts/linux/enter_enclave.S
+++ b/psw/urts/linux/enter_enclave.S
@@ -52,6 +52,7 @@ DECLARE_GLOBAL_FUNC set_xsave_info
     lea_symbol g_clean_ymm, %xax
     movl    %edx, (%xax)
     ret
+    .cfi_endproc
 
 DECLARE_GLOBAL_FUNC vdso_sgx_enter_enclave_wrapper
 EENTER_PROLOG
@@ -169,14 +170,17 @@ EENTER_PROLOG
 DECLARE_GLOBAL_FUNC get_aep
     lea_pic     .Lasync_exit_pointer, %xax
     ret
+    .cfi_endproc
 
 DECLARE_GLOBAL_FUNC get_eenterp
     lea_pic .Leenter_inst, %xax
     ret
+    .cfi_endproc
 
 DECLARE_GLOBAL_FUNC get_eretp
     lea_pic .Leret, %xax
     ret
+    .cfi_endproc
 
 /*
  * function stack_sticker is the wrapper of ocall,
@@ -208,7 +212,6 @@ DECLARE_GLOBAL_FUNC stack_sticker
 .hidden push_ocall_frame
 .type pop_ocall_frame,@function
 .hidden pop_ocall_frame
-.cfi_startproc
     push %xbp
 .cfi_def_cfa_offset     2*SE_WORDSIZE
 .cfi_offset             xbp,-2*SE_WORDSIZE
@@ -317,6 +320,7 @@ DECLARE_GLOBAL_FUNC sgx_debug_load_state_add_element
     movq %rdi, (%rsi)
 #endif
     ret
+    .cfi_endproc
 
 /*
  * void sgx_debug_unload_state_remove_element(debug_enclave_info_t* enclave_info, debug_enclave_info_t** pre_enclave_info, debug_enclave_info_t* next_enclave_info)
@@ -332,6 +336,7 @@ DECLARE_GLOBAL_FUNC sgx_debug_unload_state_remove_element
     movq %rdx, (%rsi)
 #endif
     ret
+    .cfi_endproc
 
 /* We do not need executable stack.*/   
 .section        .note.GNU-stack,"",@progbits

--- a/psw/urts/linux/enter_enclave.h
+++ b/psw/urts/linux/enter_enclave.h
@@ -53,7 +53,6 @@ lea     \symbol, \reg
 /* macro for enter_enclave
 */
 .macro EENTER_PROLOG
-.cfi_startproc
 push    %xbp
 .cfi_def_cfa_offset   2 * SE_WORDSIZE
 .cfi_offset           xbp, -2 * SE_WORDSIZE

--- a/sdk/simulation/assembly/linux/lowlib.S
+++ b/sdk/simulation/assembly/linux/lowlib.S
@@ -39,6 +39,7 @@
 DECLARE_LOCAL_FUNC get_bp
     mov %xbp, %xax
     ret
+    .cfi_endproc
 
 #define reg_xax (0 * SE_WORDSIZE)
 #define reg_xbx (1 * SE_WORDSIZE)
@@ -62,3 +63,4 @@ DECLARE_LOCAL_FUNC load_regs
     push reg_xip(%xdx)
     mov reg_xdx(%xdx), %xdx
     ret
+    .cfi_endproc

--- a/sdk/trts/linux/trts_mitigation.S
+++ b/sdk/trts/linux/trts_mitigation.S
@@ -367,6 +367,7 @@ __ct_mitigation_end:
 .global __ct_mitigation_ret
 __ct_mitigation_ret:
     ret
+    .cfi_endproc
 
 .ct_aexnotify_end:
 

--- a/sdk/trts/linux/trts_pic.S
+++ b/sdk/trts/linux/trts_pic.S
@@ -45,11 +45,15 @@
 DECLARE_LOCAL_FUNC get_enclave_base
     lea_pic __ImageBase, %xax
     ret
+    .cfi_endproc
+
 DECLARE_LOCAL_FUNC get_enclave_state
     lea_pic g_enclave_state, %xcx
     xor     %xax, %xax
     movl    (%xcx), %eax
     ret
+    .cfi_endproc
+
 DECLARE_LOCAL_FUNC set_enclave_state
     lea_pic g_enclave_state, %xax
 #ifdef LINUX32
@@ -57,6 +61,7 @@ DECLARE_LOCAL_FUNC set_enclave_state
 #endif
     movl    %edi, (%xax)
     ret
+    .cfi_endproc
 
 DECLARE_LOCAL_FUNC lock_enclave
     lea_pic g_enclave_state, %xdx
@@ -66,6 +71,7 @@ DECLARE_LOCAL_FUNC lock_enclave
     mov     $ENCLAVE_INIT_IN_PROGRESS, %ecx     /* if (g_global_data.enclave_state == ENCLAVE_INIT_NOT_STARTED) */
     lock cmpxchgl %ecx, (%xdx)                  /*   g_global_data.enclave_state == ENCLAVE_INIT_IN_PROGRESS */
     ret                                         /* xax: the initial value of enclave state */
+    .cfi_endproc
 
 /*
  * ---------------------------------------------------------------------
@@ -77,6 +83,7 @@ DECLARE_LOCAL_FUNC lock_enclave
 DECLARE_LOCAL_FUNC get_thread_data
     READ_TD_DATA self_addr
     ret
+    .cfi_endproc
 
 /*
  * ---------------------------------------------------------------------
@@ -88,6 +95,7 @@ DECLARE_LOCAL_FUNC get_thread_data
 DECLARE_LOCAL_FUNC get_stack_guard
     READ_TD_DATA stack_guard
     ret
+    .cfi_endproc
 
 /*
  * ---------------------------------------------------------------------
@@ -113,7 +121,6 @@ DECLARE_GLOBAL_FUNC enclave_entry
  *      No need to use any register during the dispatch
  * ----------------------------------------------------------------------
  */
-    .cfi_startproc
 
     /* Clear unused general registers */
     xor     %xdx, %xdx
@@ -446,6 +453,7 @@ DECLARE_LOCAL_FUNC do_ocall
     cld                         /* DF = 0 */
 
     ENCLU
+    .cfi_endproc
 
 /*
  * ------------------------------------------------------------------
@@ -454,7 +462,6 @@ DECLARE_LOCAL_FUNC do_ocall
  * ------------------------------------------------------------------
  */
 DECLARE_LOCAL_FUNC __morestack
-    .cfi_startproc
     push %xbp
     .cfi_def_cfa_offset     2*SE_WORDSIZE
     .cfi_offset             xbp,-2*SE_WORDSIZE
@@ -518,6 +525,7 @@ DECLARE_GLOBAL_FUNC asm_oret
     ret
     /* should not come here */
     ud2
+    .cfi_endproc
 
 /*
  * ------------------------------------------------------------------------
@@ -625,6 +633,7 @@ DECLARE_LOCAL_FUNC do_rdrand
     movl    %eax, (%xcx)
     mov     $1, %xax
     ret
+    .cfi_endproc
 
 /*
  * -------------------------------------------------------------------------
@@ -635,6 +644,7 @@ DECLARE_LOCAL_FUNC abort
     lea_pic g_enclave_state, %xax
     movl    $ENCLAVE_CRASHED, (%xax)
     ud2
+    .cfi_endproc
 
 /*
  * -------------------------------------------------------------------------
@@ -692,6 +702,7 @@ DECLARE_LOCAL_FUNC continue_execution
     xchg    %xax, %xsp
 
     ret     $(RED_ZONE_SIZE)           /* pop xip and red zone (if any) */
+    .cfi_endproc
 
 /* 
  * -------------------------------------------------------------------------
@@ -704,4 +715,5 @@ DECLARE_LOCAL_FUNC second_phase
     mov     $SE_EDECCSSA, %xax
     enclu                               /* DECCSSA */
     jmp     *%xdx
+    .cfi_endproc
     

--- a/sdk/tsetjmp/_setjmp.S
+++ b/sdk/tsetjmp/_setjmp.S
@@ -172,6 +172,7 @@ DECLARE_GLOBAL_FUNC setjmp
     ret
 .crash:
     ud2
+    .cfi_endproc
 
 DECLARE_GLOBAL_FUNC longjmp
 #ifdef LINUX32
@@ -272,6 +273,7 @@ DECLARE_GLOBAL_FUNC longjmp
     jnz     1f
     incl    %eax
 1:  ret
+    .cfi_endproc
 
 
 .weak _setjmp


### PR DESCRIPTION
Current macros emit an ENDBR instruction between the function label and corresponding cfi_start, which confuses binary analysis tools like llvm-bolt.

Also add missing cfi_start/end directives for other assembly functions.

See also: https://sourceware.org/binutils/docs/as/CFI-directives.html