### PR TITLE
fix a header issue in sgx_enclave_common.cpp

### DIFF
--- a/psw/enclave_common/sgx_enclave_common.cpp
+++ b/psw/enclave_common/sgx_enclave_common.cpp
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <dlfcn.h>
 #include <map>
+#include <algorithm>
 #include <functional>
 #include "sgx_enclave_common.h"
 #include "sgx_urts.h"


### PR DESCRIPTION
sgx_enclave_common.cpp [line 164](https://github.com/intel/linux-sgx/blob/c1ceb4fe146e0feb1097dee81c7e89925443e43c/psw/enclave_common/sgx_enclave_common.cpp#L164) uses `std::upper_bound`. the corresponding header file is `algorithm`. however, it's missing in sgx_enclave_common.cpp. this patch adds it and make the package compile with the latest toolchain.