### PR TITLE
Stop throwing away make stderr output

### DIFF
--- a/sdk/Makefile.source
+++ b/sdk/Makefile.source
@@ -75,7 +75,7 @@ tstdc: $(LIBTLIBC)
 
 ifndef SERVTD_ATTEST
 $(LIBTLIBC): tlibthread compiler-rt tsafecrt tsetjmp tmm_rsrv
-	$(MAKE) -C tlibc/ -j$(shell nproc) 2> /dev/null
+	$(MAKE) -C tlibc/ -j$(shell nproc)
 	@$(MKDIR) $(BUILD_DIR)/.compiler-rt $(BUILD_DIR)/.tlibthread $(BUILD_DIR)/.tsafecrt $(BUILD_DIR)/.tsetjmp $(BUILD_DIR)/.tmm_rsrv
 	@$(RM) -f $(BUILD_DIR)/.compiler-rt/*   && cd $(BUILD_DIR)/.compiler-rt && $(AR) x $(LINUX_SDK_DIR)/compiler-rt/libcompiler-rt.a
 	@$(RM) -f $(BUILD_DIR)/.tlibthread/*    && cd $(BUILD_DIR)/.tlibthread && $(AR) x $(LINUX_SDK_DIR)/tlibthread/libtlibthread.a
@@ -93,7 +93,7 @@ $(LIBTLIBC): tlibthread compiler-rt tsafecrt tsetjmp tmm_rsrv
 	@$(RM) -rf $(BUILD_DIR)/.tsetjmp $(BUILD_DIR)/.tmm_rsrv
 else
 $(LIBTLIBC): tlibthread tsafecrt tsetjmp tmm_rsrv
-	$(MAKE) -C tlibc/ SERVTD_ATTEST=1 -j$(shell nproc) 2> /dev/null
+	$(MAKE) -C tlibc/ SERVTD_ATTEST=1 -j$(shell nproc)
 	@$(MKDIR) $(BUILD_DIR)/.tlibthread $(BUILD_DIR)/.tsafecrt $(BUILD_DIR)/.tsetjmp  $(BUILD_DIR)/.tmm_rsrv
 	@$(RM) -f $(BUILD_DIR)/.tlibthread/*    && cd $(BUILD_DIR)/.tlibthread && $(AR) x $(LINUX_SDK_DIR)/tlibthread/libtlibthread.a
 	@$(RM) -f $(BUILD_DIR)/.tsafecrt/*      && cd $(BUILD_DIR)/.tsafecrt   && $(AR) x $(LINUX_SDK_DIR)/tsafecrt/libsgx_tsafecrt.a
@@ -116,7 +116,7 @@ tsafecrt:
 
 .PHONY: compiler-rt
 compiler-rt:
-	$(MAKE) -C compiler-rt/ 2> /dev/null
+	$(MAKE) -C compiler-rt/
 
 .PHONY: tsetjmp
 tsetjmp:
@@ -160,7 +160,7 @@ cpprt: libcxxrt
 
 .PHONY: tlibcxx
 tlibcxx: $(BUILD_DIR)
-	$(MAKE) -C tlibcxx/ 2> /dev/null
+	$(MAKE) -C tlibcxx/
 	$(CP) tlibcxx/README.sgx $(BUILD_DIR)/libc++_Changes_SGX.txt
 
 # ---------------------------------------------------


### PR DESCRIPTION
Calling '$(MAKE)' against a sub-directory, while redirecting the stderr output to /dev/null makes it impossible to debug build failures, as it hides all compiler error messages. Stop sending output to /dev/null, so users can figure out what's wrong when a new compiler release fails to build SGX.