### PR TITLE
Disable use of undefined DEF_WEAK macro in strptime.c

### DIFF
--- a/sdk/tlibc/time/strptime.c
+++ b/sdk/tlibc/time/strptime.c
@@ -89,7 +89,9 @@ strptime(const char *buf, const char *fmt, struct tm *tm)
 {
 	return(_strptime(buf, fmt, tm, 1));
 }
+#if 0
 DEF_WEAK(strptime);
+#endif
 
 static char *
 _strptime(const char *buf, const char *fmt, struct tm *tm, int initialize)


### PR DESCRIPTION
The strptime.c code invokes, what is presumably an undefined macro called, DEF_WEAK. The compiler can't resolve this to a function, so being traditional C, it invents a function taking arbitrary args and returning an int.

GCC 9.5.0 used in the reproducible build warns about this problem but sdk/Makefile.source is throwing stderr from the tlibc build by sending it all to /dev/null, so the warning is never seen.

New GCC 14 has turned this warning into a fatal error, such that this bug breaks the build outside of the NixOS envirnoment.

The other use of DEF_WEAK in tlibc/time/localtime.c was surrounded by '#if 0', so do the same in strptime.c