### PR TITLE
Correct ipp-crypto submodule branch name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 [submodule "ipp-crypto"]
 	path = external/ippcp_internal/ipp-crypto
 	url = https://github.com/intel/ipp-crypto.git
-	branch = ipp-crypto_2021_10_0
+	branch = ipp-crypto_2021_12_1
 [submodule "external/protobuf/protobuf_code"]
 	path = external/protobuf/protobuf_code
 	url = https://github.com/protocolbuffers/protobuf.git


### PR DESCRIPTION
Only change branch name displayed in `.gitmodules`. No change to submodule commit or source code.