### PR TITLE
psw/ae: blank out ld-linux.so interpretor path from AEs

### DIFF
--- a/psw/ae/buildenv.mk
+++ b/psw/ae/buildenv.mk
@@ -78,7 +78,7 @@ LDTFLAGS  = -L$(SGX_LIB_DIR) -Wl,--whole-archive $(TRTSLIB) -Wl,--no-whole-archi
             -Wl,--start-group $(EXTERNAL_LIB) -Wl,--end-group -Wl,--build-id       \
             -Wl,--version-script=$(ROOT_DIR)/build-scripts/enclave.lds $(ENCLAVE_LDFLAGS)
 
-LDTFLAGS += -Wl,-Map=out.map -Wl,--undefined=version -Wl,--gc-sections
+LDTFLAGS += -Wl,-Map=out.map -Wl,--undefined=version -Wl,--gc-sections -Wl,-dynamic-linker,
 
 DEFINES := -D__linux__
 


### PR DESCRIPTION
The enclaves are getting built as ELF executables, and thus the linker will embed the current ld-linux.so path for the host OS environment in the binary:

 $ readelf -a libsgx_pce.signed.so | grep interpreter
      [Requesting program interpreter: /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2]

The SGX enclaves are never loaded using ld-linux.so, as SGX has custom code for loading enclaves in the required manner.

This embedded ld-linux.so path thus serves no functional purpose, while also making it harder to do a reproducible build of the enclaves outside of the NixOS environment.

This patch blanks out the NixOS interpretor path, by setting it to the empty string.

Fixes: https://github.com/intel/linux-sgx/issues/1040

Two alternatives I considered:

 * Extending the `strip` command to add `--remove-section=.interp`.  This has the undesirable side effect that 'readelf' will complain that the AE ELF file is malformed, because ELF executables are expected to have an `.interp` section
 * Changing LDTFLAGS to add `-Wl,--shared`. This tells the linker to create an ELF file that is a shared library rather than an executable, and thus avoids creating a `.interp` section in the first place. This has a bunch of changes to the overall ELF file, however, and I was not confident that the result would be functionally correct for the SGX enclave loader.

I still believe that using `-Wl,--shared` is probably the more semantically logical approach, but using `-Wl,--dynamic-loader,` is the approach that has fewer chances of unexpected behaviour changes, hence I picked the latter here.
