### PR TITLE
buildenv: enable pointing enclave build to alternative glibc headers

### DIFF
--- a/buildenv.mk
+++ b/buildenv.mk
@@ -285,7 +285,7 @@ endif
 # When `pie' is enabled, the linker (both BFD and Gold) under Ubuntu 14.04
 # will hide all symbols from dynamic symbol table even if they are marked
 # as `global' in the LD version script.
-ENCLAVE_CFLAGS   = -ffreestanding -nostdinc -fvisibility=hidden -fpie -fno-strict-overflow -fno-delete-null-pointer-checks
+ENCLAVE_CFLAGS   = -ffreestanding -nostdinc -fvisibility=hidden -fpie -fno-strict-overflow -fno-delete-null-pointer-checks $(ENCLAVE_SYSTEM_INCLUDES)
 ENCLAVE_CXXFLAGS = $(ENCLAVE_CFLAGS) -nostdinc++
 ENCLAVE_LDFLAGS  = $(ENC_LDFLAGS) $(COMMON_LDFLAGS) -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
                    -Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \


### PR DESCRIPTION
The enclaves must be built with headers from a specific glibc version for the sake of reproducibility. It does not actually link to glibc, merely requiring a few self contained definitions. In the NixOS build env the glibc system include directories get set through various wrapper scripts NixOS creates.

When attempting a reproducible build outside of NixOS though, we can't rely on the compiler having the matching glibc system include dirs. Instead there needs to be a way to inject "-isystem/some/path" args into the enclave compiler flags.

This commit adds a "ENCLAVE_SYSTEM_INCLUDES" make var can be set by the person triggering 'make', to provide a way to inject system include directories to the enclave build process.