### PR TITLE
psw: prefer /dev/sgx_provision & /dev/sgx_enclave

### DIFF
--- a/psw/enclave_common/sgx_enclave_common.cpp
+++ b/psw/enclave_common/sgx_enclave_common.cpp
@@ -409,11 +409,11 @@ static void enclave_set_provision_access(int hdevice, void* enclave_base)
     
     if (s_driver_type == SGX_DRIVER_IN_KERNEL)
     {
-        hdev_prov = open("/dev/sgx/provision", O_RDWR);
+        hdev_prov = open("/dev/sgx_provision", O_RDWR);
         if (-1 == hdev_prov)
         {
-            //if /dev/sgx/provision is not present, try to open /dev/sgx_provision
-            hdev_prov = open("/dev/sgx_provision", O_RDWR);
+            //if /dev/sgx_provision is not present, try to open /dev/sgx/provision
+            hdev_prov = open("/dev/sgx/provision", O_RDWR);
         }
         if (-1 == hdev_prov)
         {

--- a/psw/urts/linux/edmm_utility.cpp
+++ b/psw/urts/linux/edmm_utility.cpp
@@ -99,11 +99,11 @@ bool get_driver_type(int *driver_type)
         *driver_type = sgx_driver_type;
     }
     
-    int hdev = open("/dev/sgx/enclave", O_RDWR);    //attempt to open the in-kernel driver
+    int hdev = open("/dev/sgx_enclave", O_RDWR);    //attempt to open the in-kernel driver
     if (-1 == hdev)
     {
-        //if /dev/sgx/enclave is not present, try to open /dev/sgx_enclave
-        hdev = open("/dev/sgx_enclave", O_RDWR);
+        //if /dev/sgx_enclave is not present, try to open /dev/sgx/enclave
+        hdev = open("/dev/sgx/enclave", O_RDWR);
     }
     if (-1 == hdev)
     {
@@ -155,11 +155,11 @@ extern "C" bool open_se_device(int driver_type, int *hdevice)
     *hdevice = -1;
     if (driver_type == SGX_DRIVER_IN_KERNEL)
     {
-        *hdevice = open("/dev/sgx/enclave", O_RDWR);    //attempt to open the in-kernel driver
-        //if /dev/sgx/enclave is not present, try to open /dev/sgx_enclave
+        *hdevice = open("/dev/sgx_enclave", O_RDWR);    //attempt to open the in-kernel driver
+        //if /dev/sgx_enclave is not present, try to open /dev/sgx/enclave
         if(-1 == *hdevice)
         {
-            *hdevice = open("/dev/sgx_enclave", O_RDWR);
+            *hdevice = open("/dev/sgx/enclave", O_RDWR);
         }
     }
     else if (driver_type == SGX_DRIVER_DCAP)


### PR DESCRIPTION
The default behaviour for SGX support in upstream Linux is to have /dev/sgx_provision & /dev/sgx_enclave device nodes[1], rather than /dev/sgx/provision & /dev/sgx/enclave.

The code should prefer opening the current default device nodes first, with the other paths as the fallback, so the common case will be an immediate success.

[1] https://github.com/torvalds/linux/blob/master/arch/x86/kernel/cpu/sgx/main.c
