### PR TITLE
Updated aesm_service to use C++17

### DIFF
--- a/psw/ae/aesm_service/source/CMakeLists.txt
+++ b/psw/ae/aesm_service/source/CMakeLists.txt
@@ -61,7 +61,7 @@ if(REF_LE)
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED 1)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_SKIP_BUILD_RPATH true)
 
 ########## SGX SDK Settings ##########


### PR DESCRIPTION
Updated aesm_service to use C++17.  This was failing compilation when compiling for Azure Linux 3.0