### PR TITLE
Fix /docker/build Dockerfile and docker-compose.yml under newer Linux

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -76,10 +76,22 @@ RUN make deb_local_repo
 
 FROM ubuntu:22.04 as aesm
 RUN apt-get update && apt-get install -y \
+    curl \
+    gnupg \
+    apt-transport-https \
+    ca-certificates
+
+RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
+    echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main" > /etc/apt/sources.list.d/intel-sgx.list && \
+    apt-get update
+
+RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libprotobuf-dev \
     libssl-dev \
-    make
+    make \
+    libsgx-dcap-ql \
+    libsgx-dcap-default-qpl
 
 WORKDIR /installer
 COPY --from=builder /linux-sgx/linux/installer/bin/*.bin ./

--- a/docker/build/docker-compose.yml
+++ b/docker/build/docker-compose.yml
@@ -36,8 +36,8 @@ services:
   aesm:
     image: sgx_aesm
     devices:
-      - /dev/sgx/enclave
-      - /dev/sgx/provision
+      - /dev/sgx_enclave
+      - /dev/sgx_provision
     volumes:
       - aesmd-socket:/var/run/aesmd
     stdin_open: true
@@ -51,7 +51,7 @@ services:
     depends_on:
       - aesm
     devices:
-      - /dev/sgx/enclave
+      - /dev/sgx_enclave
     volumes:
       - aesmd-socket:/var/run/aesmd
     stdin_open: true


### PR DESCRIPTION
SGX device driver has been moved to `/dev/sgx_xxxx` in upstream kernel and aesm Docker `"Cannot open Quote Provider Library libcap_quoteprov.so.1 and libcap_quoteprov.so".`

Fix `/dev/sgx/` location in `docker-compose-yml` and add installation of `dcap-al` and `dcap-default-qpl`.

run `./build_compose_run.sh` :
<img width="605" alt="image" src="https://github.com/user-attachments/assets/cfccb1e2-1782-4aaf-8eaa-c85b72f7966d" />

Signed-off-by: Kunlin Li kli082@connect.hkust-gz.edu.cn