### PR TITLE
 #1073: Caching hash method pointers globally to improve performances

### DIFF
--- a/common/inc/internal/se_tcrypto_common.h
+++ b/common/inc/internal/se_tcrypto_common.h
@@ -52,6 +52,17 @@ extern unsigned long openssl_last_err;
 
 #endif //DEBUG
 
+#else
+
+#include "ippcp.h"
+
+struct TcryptoIppsHashMethods {
+    const IppsHashMethod* sha1HashMethod;
+    const IppsHashMethod* sha256HashMethod;
+    const IppsHashMethod* sha384HashMethod;
+};
+
+extern TcryptoIppsHashMethods IPPS_HASH_METHODS;
 
 #endif //USE_SGXSSL
 

--- a/sdk/tlibcrypto/Makefile
+++ b/sdk/tlibcrypto/Makefile
@@ -104,16 +104,16 @@ TARGET := libsgx_tcrypto.a
 ifeq ($(USE_CRYPTO_LIB), 0)
 
 $(TARGET): PREPARE_SGX_SSL
-	$(MAKE) $(OBJ) 
+	$(MAKE) $(OBJ)
 	$(MAKE) $(SHARED_OBJ)
 	$(MKDIR) $(BUILD_DIR)/.libs
 	$(RM) $(BUILD_DIR)/.libs/*
 	cd $(BUILD_DIR)/.libs && \
 	$(AR) x $(OPENSSL_LIBRARY_PATH)/lib$(OpenSSL_Crypto_Library_Name).a && \
-	$(AR) x $(OPENSSL_LIBRARY_PATH)/lib$(SGXSSL_Library_Name).a 
+	$(AR) x $(OPENSSL_LIBRARY_PATH)/lib$(SGXSSL_Library_Name).a
 	$(AR) rsD $(LIB_NAME) $(OBJ) $(SHARED_OBJ) $(BUILD_DIR)/.libs/*.o
 	$(CP) $(LIB_NAME) $@
-	$(RM) -r $(BUILD_DIR)/.libs 
+	$(RM) -r $(BUILD_DIR)/.libs
 else
 
 $(TARGET): $(OBJ) $(SHARED_OBJ) $(C_OBJS)
@@ -123,6 +123,8 @@ $(TARGET): $(OBJ) $(SHARED_OBJ) $(C_OBJS)
 
 # SHA1 is already deprecated, remove -Werror
 ipp/sgx_sha1.o: ipp/sgx_sha1.cpp
+	$(CXX) -c $(filter-out -Werror,$(CXXFLAGS))  $(CPPFLAGS) $< -o $@
+ipp/init_tcrypto_lib.o: ipp/init_tcrypto_lib.cpp
 	$(CXX) -c $(filter-out -Werror,$(CXXFLAGS))  $(CPPFLAGS) $< -o $@
 endif #($(USE_CRYPTO_LIB), 0)
 

--- a/sdk/tlibcrypto/ipp/init_tcrypto_lib.cpp
+++ b/sdk/tlibcrypto/ipp/init_tcrypto_lib.cpp
@@ -34,10 +34,12 @@
 #include "ippcp.h"
 #include "se_cpu_feature.h"
 #include "se_cdefs.h"
+#include "se_tcrypto_common.h"
 
 // add a version to tcrypto.
 SGX_ACCESS_VERSION(tcrypto, 1)
 
+TcryptoIppsHashMethods IPPS_HASH_METHODS;
 
 extern "C" sgx_status_t init_ipp_cpuid(uint64_t cpu_feature_indicator);
 /* Crypto Library Initialization
@@ -48,6 +50,11 @@ extern "C" sgx_status_t sgx_init_crypto_lib(uint64_t cpu_feature_indicator, uint
 {
     (void)(cpuid_table);
 
-    return init_ipp_cpuid(cpu_feature_indicator);
-}
+    sgx_status_t status = init_ipp_cpuid(cpu_feature_indicator);
 
+    IPPS_HASH_METHODS.sha1HashMethod = ippsHashMethod_SHA1_TT();
+    IPPS_HASH_METHODS.sha256HashMethod = ippsHashMethod_SHA256_TT();
+    IPPS_HASH_METHODS.sha384HashMethod = ippsHashMethod_SHA384();
+
+    return status;
+}

--- a/sdk/tlibcrypto/ipp/sgx_ecc256_ecdsa.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_ecc256_ecdsa.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "ipp_wrapper.h"
+#include "se_tcrypto_common.h"
 #include "sgx_fips_internal.h"
 
 const uint32_t sgx_nistp256_r[] = {
@@ -82,7 +83,7 @@ sgx_status_t sgx_ecdsa_sign(const uint8_t *p_data,
         ERROR_BREAK(ipp_ret);
 
         // Prepare the message used to sign.
-        ipp_ret = ippsHashMessage_rmf(p_data, data_size, (Ipp8u *)hash, ippsHashMethod_SHA256_TT());
+        ipp_ret = ippsHashMessage_rmf(p_data, data_size, (Ipp8u *)hash, IPPS_HASH_METHODS.sha256HashMethod);
         ERROR_BREAK(ipp_ret);
         /* Byte swap in creation of Big Number from SHA256 hash output */
         ipp_ret = sgx_ipp_newBN(NULL, sizeof(hash), &p_hash_bn);
@@ -213,7 +214,7 @@ sgx_status_t sgx_ecdsa_verify(const uint8_t *p_data,
     uint8_t hash[SGX_SHA256_HASH_SIZE] = {0};
 
     // Prepare the message used to sign.
-    if (ippStsNoErr != ippsHashMessage_rmf(p_data, data_size, (Ipp8u *)hash, ippsHashMethod_SHA256_TT()))
+    if (ippStsNoErr != ippsHashMessage_rmf(p_data, data_size, (Ipp8u *)hash, IPPS_HASH_METHODS.sha256HashMethod))
     {
         return SGX_ERROR_INVALID_PARAMETER;
     }

--- a/sdk/tlibcrypto/ipp/sgx_hmac.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_hmac.cpp
@@ -35,6 +35,7 @@
 #include "stdlib.h"
 #include "string.h"
 #include "sgx_fips_internal.h"
+#include "se_tcrypto_common.h"
 
 static void fips_self_test_hmac()
 {
@@ -88,7 +89,7 @@ sgx_status_t sgx_hmac_sha256_msg(const unsigned char *p_src, int src_len, const 
 
     do
     {
-        ipp_ret = ippsHMACMessage_rmf(p_src, src_len, (const Ipp8u *)p_key, key_len, p_mac, mac_len, ippsHashMethod_SHA256_TT());
+        ipp_ret = ippsHMACMessage_rmf(p_src, src_len, (const Ipp8u *)p_key, key_len, p_mac, mac_len, IPPS_HASH_METHODS.sha256HashMethod);
         ERROR_BREAK(ipp_ret);
 
         ret = SGX_SUCCESS;
@@ -135,7 +136,7 @@ sgx_status_t sgx_hmac256_init(const unsigned char *p_key, int key_len, sgx_hmac_
             ret = SGX_ERROR_OUT_OF_MEMORY;
             break;
         }
-        ipp_ret = ippsHMACInit_rmf(p_key, key_len, pState, ippsHashMethod_SHA256_TT());
+        ipp_ret = ippsHMACInit_rmf(p_key, key_len, pState, IPPS_HASH_METHODS.sha256HashMethod);
         ERROR_BREAK(ipp_ret);
 
         *p_hmac_handle = pState;

--- a/sdk/tlibcrypto/ipp/sgx_rsa3072.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_rsa3072.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "ipp_wrapper.h"
+#include "se_tcrypto_common.h"
 #include "sgx_fips_internal.h"
 
 static void fips_self_test_rsa_sign_verify()
@@ -188,7 +189,7 @@ sgx_status_t sgx_rsa3072_sign_ex(const uint8_t *p_data,
         }
 
         // sign the data buffer
-        ipp_ret = ippsRSASign_PKCS1v15_rmf(p_data, data_size, *p_signature, p_rsa_privatekey_ctx, p_rsa_publickey_ctx, ippsHashMethod_SHA256_TT(), temp_buff);
+        ipp_ret = ippsRSASign_PKCS1v15_rmf(p_data, data_size, *p_signature, p_rsa_privatekey_ctx, p_rsa_publickey_ctx, IPPS_HASH_METHODS.sha256HashMethod, temp_buff);
 
     } while (0);
 
@@ -300,7 +301,7 @@ sgx_status_t sgx_rsa3072_verify(const uint8_t *p_data,
         }
 
         // verify the signature
-        ipp_ret = ippsRSAVerify_PKCS1v15_rmf(p_data, data_size, *p_signature, &result, p_rsa_publickey_ctx, ippsHashMethod_SHA256_TT(), temp_buff);
+        ipp_ret = ippsRSAVerify_PKCS1v15_rmf(p_data, data_size, *p_signature, &result, p_rsa_publickey_ctx, IPPS_HASH_METHODS.sha256HashMethod, temp_buff);
     } while (0);
 
     if ((result != 0) && (ipp_ret == ippStsNoErr))

--- a/sdk/tlibcrypto/ipp/sgx_rsa_encryption.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_rsa_encryption.cpp
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+#include "se_tcrypto_common.h"
 #include "sgx_error.h"
 #include "sgx_trts.h"
 #include "ipp_wrapper.h"
@@ -258,7 +259,7 @@ sgx_status_t sgx_create_rsa_priv2_key(int mod_size, int exp_size, const unsigned
     IppsBigNumState *p_p = NULL, *p_q = NULL, *p_dmp1 = NULL, *p_dmq1 = NULL, *p_iqmp = NULL;
     int rsa2_size = 0;
     sgx_status_t ret_code = SGX_ERROR_UNEXPECTED;
-    if (mod_size <= 0 || p_rsa_key_p == NULL || p_rsa_key_q == NULL || p_rsa_key_dmp1 == NULL || p_rsa_key_dmq1 == NULL 
+    if (mod_size <= 0 || p_rsa_key_p == NULL || p_rsa_key_q == NULL || p_rsa_key_dmp1 == NULL || p_rsa_key_dmq1 == NULL
         || p_rsa_key_iqmp == NULL || new_pri_key2 == NULL)
     {
         return SGX_ERROR_INVALID_PARAMETER;
@@ -460,7 +461,7 @@ sgx_status_t sgx_rsa_pub_encrypt_sha256(const void *rsa_key, unsigned char *pout
         // encrypt input data with public rsa_key and SHA256 padding
         //
         if (ippsRSAEncrypt_OAEP_rmf(pin_data, (int)pin_len, NULL, 0, seeds,
-                                    pout_data, (IppsRSAPublicKeyState *)rsa_key, ippsHashMethod_SHA256_TT(), p_scratch_buffer) != ippStsNoErr)
+                                    pout_data, (IppsRSAPublicKeyState *)rsa_key, IPPS_HASH_METHODS.sha256HashMethod, p_scratch_buffer) != ippStsNoErr)
         {
             break;
         }
@@ -555,7 +556,7 @@ sgx_status_t sgx_rsa_priv_decrypt_sha256(const void *rsa_key, unsigned char *pou
 
         // decrypt input ciphertext using private key rsa_key
         if (ippsRSADecrypt_OAEP_rmf(pin_data, NULL, 0, pout_data, (int *)pout_len, (IppsRSAPrivateKeyState *)rsa_key,
-                                    ippsHashMethod_SHA256_TT(), p_scratch_buffer) != ippStsNoErr)
+                                    IPPS_HASH_METHODS.sha256HashMethod, p_scratch_buffer) != ippStsNoErr)
         {
             break;
         }
@@ -568,7 +569,7 @@ sgx_status_t sgx_rsa_priv_decrypt_sha256(const void *rsa_key, unsigned char *pou
     return ret_code;
 }
 
-sgx_status_t sgx_create_rsa_priv1_key(int n_byte_size, int e_byte_size, int d_byte_size, const unsigned char *le_n, 
+sgx_status_t sgx_create_rsa_priv1_key(int n_byte_size, int e_byte_size, int d_byte_size, const unsigned char *le_n,
                                       const unsigned char *le_e, const unsigned char *le_d, void **new_pri_key1)
 {
     if (n_byte_size <= 0 || e_byte_size <= 0 || d_byte_size <= 0 || new_pri_key1 == NULL ||

--- a/sdk/tlibcrypto/ipp/sgx_sha1.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_sha1.cpp
@@ -32,6 +32,7 @@
 #include "ippcp.h"
 #include "sgx_tcrypto.h"
 #include "stdlib.h"
+#include "se_tcrypto_common.h"
 
 #ifndef SAFE_FREE
 #define SAFE_FREE(ptr) {if (NULL != (ptr)) {free(ptr); (ptr)=NULL;}}
@@ -52,7 +53,7 @@ sgx_status_t sgx_sha1_msg(const uint8_t *p_src, uint32_t src_len, sgx_sha1_hash_
     }
 
     IppStatus ipp_ret = ippStsNoErr;
-    ipp_ret = ippsHashMessage_rmf((const Ipp8u *) p_src, src_len, (Ipp8u *)p_hash, ippsHashMethod_SHA1_TT());
+    ipp_ret = ippsHashMessage_rmf((const Ipp8u *) p_src, src_len, (Ipp8u *)p_hash, IPPS_HASH_METHODS.sha1HashMethod);
     switch (ipp_ret)
     {
     case ippStsNoErr: return SGX_SUCCESS;
@@ -84,7 +85,7 @@ sgx_status_t sgx_sha1_init(sgx_sha_state_handle_t* p_sha_handle)
     p_temp_state = (IppsHashState_rmf*)(malloc(ctx_size));
     if (p_temp_state == NULL)
         return SGX_ERROR_OUT_OF_MEMORY;
-    ipp_ret = ippsHashInit_rmf(p_temp_state, ippsHashMethod_SHA1_TT());
+    ipp_ret = ippsHashInit_rmf(p_temp_state, IPPS_HASH_METHODS.sha1HashMethod);
     if (ipp_ret != ippStsNoErr)
     {
         SAFE_FREE(p_temp_state);

--- a/sdk/tlibcrypto/ipp/sgx_sha256.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_sha256.cpp
@@ -33,6 +33,7 @@
 #include "sgx_tcrypto.h"
 #include "stdlib.h"
 #include "sgx_fips_internal.h"
+#include "se_tcrypto_common.h"
 
 #ifndef SAFE_FREE
 #define SAFE_FREE(ptr)     \
@@ -94,7 +95,7 @@ sgx_status_t sgx_sha256_init(sgx_sha_state_handle_t *p_sha_handle)
     p_temp_state = (IppsHashState_rmf *)(malloc(ctx_size));
     if (p_temp_state == NULL)
         return SGX_ERROR_OUT_OF_MEMORY;
-    ipp_ret = ippsHashInit_rmf(p_temp_state, ippsHashMethod_SHA256_TT());
+    ipp_ret = ippsHashInit_rmf(p_temp_state, IPPS_HASH_METHODS.sha256HashMethod);
     if (ipp_ret != ippStsNoErr)
     {
         SAFE_FREE(p_temp_state);

--- a/sdk/tlibcrypto/ipp/sgx_sha256_msg.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_sha256_msg.cpp
@@ -34,6 +34,7 @@
 #include "ippcp.h"
 #include "stdlib.h"
 #include "sgx_fips_internal.h"
+#include "se_tcrypto_common.h"
 
 #ifndef SAFE_FREE
 #define SAFE_FREE(ptr) {if (NULL != (ptr)) {free(ptr); (ptr)=NULL;}}
@@ -56,7 +57,7 @@ sgx_status_t sgx_sha256_msg(const uint8_t *p_src, uint32_t src_len, sgx_sha256_h
     fips_self_test_hash256();
 
     IppStatus ipp_ret = ippStsNoErr;
-    ipp_ret = ippsHashMessage_rmf((const Ipp8u *) p_src, src_len, (Ipp8u *)p_hash, ippsHashMethod_SHA256_TT());
+    ipp_ret = ippsHashMessage_rmf((const Ipp8u *) p_src, src_len, (Ipp8u *)p_hash, IPPS_HASH_METHODS.sha256HashMethod);
     switch (ipp_ret)
     {
     case ippStsNoErr: return SGX_SUCCESS;

--- a/sdk/tlibcrypto/ipp/sgx_sha384.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_sha384.cpp
@@ -33,6 +33,7 @@
 #include "sgx_tcrypto.h"
 #include "stdlib.h"
 #include "sgx_fips_internal.h"
+#include "se_tcrypto_common.h"
 
 #ifndef SAFE_FREE
 #define SAFE_FREE(ptr) {if (NULL != (ptr)) {free(ptr); (ptr)=NULL;}}
@@ -87,7 +88,7 @@ sgx_status_t sgx_sha384_init(sgx_sha_state_handle_t *p_sha_handle)
     p_temp_state = (IppsHashState_rmf *)(malloc(ctx_size));
     if (p_temp_state == NULL)
         return SGX_ERROR_OUT_OF_MEMORY;
-    ipp_ret = ippsHashInit_rmf(p_temp_state, ippsHashMethod_SHA384());
+    ipp_ret = ippsHashInit_rmf(p_temp_state, IPPS_HASH_METHODS.sha384HashMethod);
     if (ipp_ret != ippStsNoErr)
     {
         SAFE_FREE(p_temp_state);

--- a/sdk/tlibcrypto/ipp/sgx_sha384_msg.cpp
+++ b/sdk/tlibcrypto/ipp/sgx_sha384_msg.cpp
@@ -34,6 +34,7 @@
 #include "ippcp.h"
 #include "stdlib.h"
 #include "sgx_fips_internal.h"
+#include "se_tcrypto_common.h"
 
 #ifndef SAFE_FREE
 #define SAFE_FREE(ptr) {if (NULL != (ptr)) {free(ptr); (ptr)=NULL;}}
@@ -56,7 +57,7 @@ sgx_status_t sgx_sha384_msg(const uint8_t *p_src, uint32_t src_len, sgx_sha384_h
     fips_self_test_hash384();
 
     IppStatus ipp_ret = ippStsNoErr;
-    ipp_ret = ippsHashMessage_rmf((const Ipp8u *) p_src, src_len, (Ipp8u *)p_hash, ippsHashMethod_SHA384());
+    ipp_ret = ippsHashMessage_rmf((const Ipp8u *) p_src, src_len, (Ipp8u *)p_hash, IPPS_HASH_METHODS.sha384HashMethod);
     switch (ipp_ret)
     {
     case ippStsNoErr: return SGX_SUCCESS;


### PR DESCRIPTION
This PR fixes the performance issue with TCrypto hash functions we've observed as explained in issue intel/confidential-computing.sgx.sdk#168.

# Summary of the changes

* common/inc/internal/se_tcrypto_common.h: add a global structure containing IppsHashMethod pointers when TCrypto is build with IPP
* sdk/tlibcrypto/ipp/init_tcrypto_lib.cpp: populate the global hash methods structure after IPP has been initialized with CPUID values.
* sdk/tlibcrypto/Makefile: avoid SHA1 deprecation warning when building init_tcrypto_lib.cpp.
* other sdk/tlibcrypto/ipp/*.cpp files: switch to use the global hash method structure.

I've also performed the change in RSA and ECC code but haven't benchmarked it. However I don't expect a significant performance uplift in those cases. I simply did it for consistency.

I'm also unsure of what code conventions I should follow so please don't hesitate to ask for such changes.

# Performance data

The following benchmark were run on a dual Intel(R) Xeon(R) Silver 4310 system. The support of SHANI amplify the magnitude of the issue so systems without SHANI support will see a smaller uplift.

Benchmarks can be replicated using the enclave code here: https://github.com/haxelion/sgx_tcrypto_bench

The benchmark code perform 1,000,000 iteration of the selected algorithm inside an ECALL. Several of those ECALL are called in parallel from multiple threads. What is expected is that, up to the core count, there shouldn't be any noticeable slowdown.

I've also attached the detailed console output to this PR: [Intel TCrypto benchmark data.md](https://github.com/user-attachments/files/19904503/Intel.TCrypto.benchmark.data.md).

## SHA1

| Thread count |             1 |             2 |             6 |            12 |            24 |
| :---                 |          ---: |          ---: |          ---: |          ---: |          ---: |
| Without fix     | 87 ms | 727 ms | 1093 ms | 1977 ms | 3684 ms |
| With fix     | 83 ms | 83 ms | 83 ms | 83 ms | 84 ms |

24 threads speed-up: 44x

## SHA256

| Thread count |             1 |             2 |             6 |            12 |            24 |
| :---                 |          ---: |          ---: |          ---: |          ---: |          ---: |
| Without fix     | 114 ms | 884 ms | 1671 ms | 2883 ms | 4732 ms |
| With fix     | 107 ms | 108 ms | 107 ms | 110 ms | 109 ms |

24 threads speed-up: 43x

## HMAC-SHA256

| Thread count |             1 |             2 |             6 |            12 |            24 |
| :---                 |          ---: |          ---: |          ---: |          ---: |          ---: |
| Without fix     | 640 ms | 766 ms | 3404 ms | 6183 ms | 8875 ms |
| With fix     | 636 ms | 636 ms | 634 ms | 640 ms | 637 ms |

24 threads speed-up: 14x

## SHA384

| Thread count |             1 |             2 |             6 |            12 |            24 |
| :---                 |          ---: |          ---: |          ---: |          ---: |          ---: |
| Without fix     | 332 ms | 1018 ms | 1451 ms | 2263 ms | 4074 ms |
| With fix     | 333 ms | 333 ms | 333 ms | 333 ms | 333 ms |

24 threads speed-up: 12x