### PR TITLE
Fix memory leak of RSA public key

### DIFF
--- a/psw/urts/urts_com.h
+++ b/psw/urts/urts_com.h
@@ -256,8 +256,10 @@ static sgx_status_t get_metadata(BinParser *parser, const int debug, metadata_t 
                 return SGX_ERROR_INVALID_METADATA;
             }
             if (false == verify_rsa3072_signature(pkey, (const uint8_t *)&target_metadata->enclave_css, sizeof(target_metadata->enclave_css), sig->signature, sizeof(sig->signature))) {
+                free_rsa_key(pkey);
                 return SGX_ERROR_INVALID_METADATA;
             }
+            free_rsa_key(pkey);
         }
     }
 


### PR DESCRIPTION
Fix memory leak of the RSA key returned by the call to `create_rsa_pub_key` on line 254.