### PR TITLE
Fix typo in `__GNUC_PREREQ__` version check

### DIFF
--- a/common/inc/tlibc/sys/cdefs.h
+++ b/common/inc/tlibc/sys/cdefs.h
@@ -57,7 +57,7 @@
 /*
  * Macro to test if we're using a specific version of gcc or later.
  */
-#if defined __GNUC__ && defined __GNUC_MINOR_
+#if defined __GNUC__ && defined __GNUC_MINOR__
 # define __GNUC_PREREQ__(ma, mi) \
     ((__GNUC__ > (ma)) || (__GNUC__ == (ma) && __GNUC_MINOR__ >= (mi)))
 #else


### PR DESCRIPTION
`__GNUC_MINOR__` was missing a trailing underscore, which prevented `__builtin_expect()` from being used via `__predict_false()` in the error path of checked functions like [`__memcpy_chk()`](https://github.com/intel/linux-sgx/blob/main/sdk/tlibc/gen/__memcpy_chk.cpp). `__builtin_expect` is defined from [GCC 3](https://gcc.gnu.org/gcc-3.0/features.html) (2001) and [Clang 2.2](https://github.com/llvm/llvm-project/commit/a96fe8d5c5ee87f8acd8620d53a73bcbbeddce75) (2008).