### PR TITLE
Pin nixpkgs version

### DIFF
--- a/linux/reproducibility/Dockerfile
+++ b/linux/reproducibility/Dockerfile
@@ -15,7 +15,7 @@ ENV USER user
 WORKDIR /home/user
 
 #create the shell config
-RUN echo "{ pkgs ? import <nixpkgs> {} }: \n\
+RUN echo "{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.05.tar.gz") {} }: \n\
 with pkgs; \n\
 \n\
 stdenvNoCC.mkDerivation { \n\


### PR DESCRIPTION
Trying to do the reproducible build right now results in the following error in step 10 of the Dockerfile:

```
error: evaluation aborted with the following error message: '
       This version of Nixpkgs requires an implementation of Nix with the following features:
       - `builtins.nixVersion` reports at least 2.18

       Your are evaluating with Nix 2.9.0, please upgrade:

       - If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.

       - Alternatively, with Nix > 2.0 `nix upgrade-nix' can be used to imperatively
         upgrade Nix. You may use `nix-env --version' to check which version you have.

       - If you installed Nix using the install script (https://nixos.org/nix/install),
         it is safe to upgrade by running it again:

             curl -L https://nixos.org/nix/install | sh

       For more information, please see the NixOS release notes at
       https://nixos.org/nixos/manual or locally at
       /nix/store/6hg0kq5x9sdma1bmva3qj18zbqdpp5q5-nixpkgs/nixpkgs/nixos/doc/manual/release-notes.

       If you need further help, see https://nixos.org/nixos/support.html
       '
(use '--show-trace' to show detailed location information)
The command '/bin/sh -c . /home/user/.nix-profile/etc/profile.d/nix.sh && nix-shell' returned a non-zero code: 1
Unable to find image 'sgx.build.env:latest' locally
docker: Error response from daemon: pull access denied for sgx.build.env, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```

The problem seems to be that `nixpkgs` is not pinned and always using the latest version. This PR pins the `nixpkgs` version to 22.05, which is the version that was available when Nix 2.9 was released.

More details about nixpkgs pinning:
https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.html
https://nix.dev/reference/pinning-nixpkgs.html