### PR TITLE
Fix modern C function prototype compliance

### DIFF
--- a/common/inc/internal/se_cdefs.h
+++ b/common/inc/internal/se_cdefs.h
@@ -94,7 +94,7 @@
 
 #define SGX_ACCESS_VERSION(libname, num)                    \
     MY_EXTERN char sgx_##libname##_version[];          \
-    MY_EXTERN char * __attribute__((destructor)) libname##_access_version_dummy##num()      \
+    MY_EXTERN char * __attribute__((destructor)) libname##_access_version_dummy##num(void)  \
     {                                                                                       \
         sgx_##libname##_version[0] = 's';                                                   \
         return sgx_##libname##_version;                                                     \

--- a/sdk/debugger_interface/linux/se_ptrace.c
+++ b/sdk/debugger_interface/linux/se_ptrace.c
@@ -76,7 +76,7 @@ typedef pid_t (*waitpid_t)(pid_t pid, int *status, int options);
 
 static ptrace_t g_sys_ptrace = NULL;
 static waitpid_t g_sys_waitpid = NULL;
-__attribute__((constructor)) void init()
+__attribute__((constructor)) void init(void)
 {
     g_sys_ptrace = (ptrace_t)dlsym(RTLD_NEXT, "ptrace");
     g_sys_waitpid = (waitpid_t)dlsym(RTLD_NEXT, "waitpid");


### PR DESCRIPTION
With GCC >= 14 proper function prototypes are required to be used in all C code.