### PR TITLE
sdk: avoid failure due to attribute(regparm) with GCC 16

### DIFF
--- a/psw/urts/linux/Makefile
+++ b/psw/urts/linux/Makefile
@@ -36,10 +36,10 @@ CXXFLAGS += -DDISABLE_TRACE
 CFLAGS += -DDISABLE_TRACE
 endif
 
-CXXFLAGS += -fPIC -Werror -g
+CXXFLAGS += -fPIC -Werror -Wno-attributes -g
 CXXFLAGS += $(ADDED_INC)
 
-CFLAGS += -fPIC -Werror -g
+CFLAGS += -fPIC -Werror -Wno-attributes -g
 CFLAGS += $(ADDED_INC)
 
 VTUNE_DIR = $(LINUX_EXTERNAL_DIR)/vtune/linux

--- a/sdk/simulation/trtssim/linux/Makefile
+++ b/sdk/simulation/trtssim/linux/Makefile
@@ -41,8 +41,8 @@ CPPFLAGS += -I$(COMMON_DIR)/inc/         \
 
 CFLAGS   += $(ENCLAVE_CFLAGS)
 ASFLAGS  := -DSE_SIM -Werror $(CFLAGS)
-CFLAGS   += -DSE_SIM -Werror -fasynchronous-unwind-tables
-CXXFLAGS += -DSE_SIM -Werror $(ENCLAVE_CXXFLAGS)\
+CFLAGS   += -DSE_SIM -Werror -Wno-attributes -fasynchronous-unwind-tables
+CXXFLAGS += -DSE_SIM -Werror -Wno-attributes $(ENCLAVE_CXXFLAGS)\
             -fno-exceptions -fno-rtti
 
 SIM_DIR    := $(CUR_DIR)/../..

--- a/sdk/simulation/urtssim/linux/Makefile
+++ b/sdk/simulation/urtssim/linux/Makefile
@@ -39,8 +39,8 @@ CXXFLAGS += -DDISABLE_TRACE
 CFLAGS += -DDISABLE_TRACE
 endif
 
-CXXFLAGS += -fPIC -DSE_SIM -Werror -g $(CET_FLAGS)
-CFLAGS   += -fPIC -DSE_SIM -Werror -g $(CET_FLAGS)
+CXXFLAGS += -fPIC -DSE_SIM -Werror -Wno-attributes -g $(CET_FLAGS)
+CFLAGS   += -fPIC -DSE_SIM -Werror -Wno-attributes -g $(CET_FLAGS)
 
 PREBUILT_OPENSSL_DIR := $(LINUX_EXTERNAL_DIR)/dcap_source/prebuilt/openssl
 CRYPTO_LIB := -L$(PREBUILT_OPENSSL_DIR)/lib/linux64 -lcrypto

--- a/sdk/trts/Makefile
+++ b/sdk/trts/Makefile
@@ -14,6 +14,7 @@ CPPFLAGS += -I$(COMMON_DIR)/inc          \
 
 CXXFLAGS += $(ENCLAVE_CXXFLAGS) \
             -Werror         \
+            -Wno-attributes \
             -fno-exceptions \
             -fno-rtti
 


### PR DESCRIPTION
GCC >= 16 now warns about use of attribute(regparm) on x86_64 targets. The attribute was always ignored on x86_64, so only had effect on i686 and thus the warning can be safely ignored.

As a possible alternative to this, could the use of regparm be removed entirely ?

```
$ git grep regparm
external/sgx-emm/api_tests/App/App.cpp:#define fastcall __attribute__((regparm(3),noinline,visibility("default")))
psw/urts/linux/debugger_support.cpp:#define fastcall __attribute__((regparm(3)))
psw/urts/tcs.cpp:#define fastcall __attribute__((regparm(3),noinline,visibility("default")))
sdk/compiler-rt/stack_chk.c:void __attribute__ ((regparm(1))) __intel_security_check_cookie(void * cookie)
sdk/trts/linux/tls_support.c:void * __attribute__((__regparm__(1))) ___tls_get_addr(tls_index *ti)
sdk/trts/linux/trts_pic.S: * extern "C" __attribute__((regparm(1))) void continue_execution(sgx_exception_info_t *info);
sdk/trts/linux/trts_pic.S: * extern "C" __attribute__((regparm(1))) void second_phase(sgx_exception_info_t *info, 
sdk/trts/trts_veh.cpp:extern "C" __attribute__((regparm(1))) void continue_execution(sgx_exception_info_t *info);
sdk/trts/trts_veh.cpp:extern "C" __attribute__((regparm(1))) void second_phase(sgx_exception_info_t *info, 
sdk/trts/trts_veh.cpp:extern "C" __attribute__((regparm(1))) void internal_handle_exception(sgx_exception_info_t *info)
```

I'm unclear whether SGX still considers 32-bit builds a valid target ? If x86_64 is the only valid build target, then since regparam is a no-op it could be removed. This patch takes the conservative approach and leaves it present in case it is important for 32-bit still.