### PR TITLE
[aesmd] Fix breaking change in InitQuoteExRequest schema+handling

### DIFF
--- a/psw/ae/aesm_service/source/core/ipc/AEInitQuoteExRequest.cpp
+++ b/psw/ae/aesm_service/source/core/ipc/AEInitQuoteExRequest.cpp
@@ -107,9 +107,6 @@ bool AEInitQuoteExRequest::check()
         m_request->att_key_id().size() != sizeof(sgx_att_key_id_t))
         return false;
 
-    if (!m_request->has_buf_size())
-        return false;
-
     if (m_request->b_pub_key_id())
     {
         if (m_request->buf_size() > MAX_PUB_KEY_ID_BUF_SIZE)

--- a/psw/ae/aesm_service/source/core/ipc/messages.proto
+++ b/psw/ae/aesm_service/source/core/ipc/messages.proto
@@ -45,7 +45,7 @@ message Request{
     message InitQuoteExRequest{
         optional    bytes  att_key_id              = 1;
         required    bool   b_pub_key_id            = 3;
-        required    uint64 buf_size                = 4;
+        optional    uint64 buf_size                = 4;
         optional    uint32 timeout                 = 9;
     }
 


### PR DESCRIPTION
### Problem

This commit included in v2.30 [d630abf6 - Harden AESM IPC request parsing and semantic validation](https://github.com/intel/confidential-computing.sgx/commit/d630abf6a6112dc1ea586dc4ae88b79e829212fd) breaks backwards compatibility. Clients or enclaves using v2.29 clients and older can no longer get remote attestations.

### Cause

The issue is overly-strict hardening that breaks old clients, even when it is not strictly necessary. Specifically, `InitQuoteExRequest.buf_size` went from `optional` to `required`:

```diff
     message InitQuoteExRequest{
         optional    bytes  att_key_id              = 1;
         required    bool   b_pub_key_id            = 3;
-        optional    uint64 buf_size                = 4;
+        required    uint64 buf_size                = 4;
         optional    uint32 timeout                 = 9;
     }
```

You can see relevant log lines where `aesmd` rejects a pubkey size request from an old enclave:

```
Aug 10 22:41:24 aesm_service[2281]: E0000 00:00:1786401684.179879    2281 message_lite.cc:214] Can't parse message of type "aesm.message.Request" because it is missing required fields: (cannot determine missing fields for lite message)
```

Before the hardening change, v2.29 clients omitted `buf_size` when `b_pub_key_id=false` (essentially querying the pubkey size). Making the field `required` causes `aesmd` from v2.30 to reject requests generated by prev. SGX releases.

### Fix

Fortunately, we can both keep the max `buf_size` hardening and maintain backwards compatibility. When `b_pub_key_id` is set, it still correctly rejects `buf_size` unset or `buf_size=0`. But when `b_pub_key_id` is unset, we'll allow `buf_size` unset or `buf_size=0`. Recall that proto2 getters return default values for unset optional fields, so `buf_size() == 0` when unset. This way old enclaves keep working, and we can enjoy a safer `aesmd` : )